### PR TITLE
Docplex utils methods to generate square matrix variables

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -47,6 +47,18 @@ Filtering
     NoDimRed
     NaiveDimRed
 
+Docplex
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _filtering_api:
+.. currentmodule:: pyriemann_qiskit.utils.docplex
+
+.. autosummary::
+    :toctree: generated/
+
+    covmat_cont_var
+    covmat_int_var
+    covmat_bin_var
+
 Datasets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. _datasets_api:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -55,9 +55,9 @@ Docplex
 .. autosummary::
     :toctree: generated/
 
-    covmat_cont_var
-    covmat_int_var
-    covmat_bin_var
+    square_cont_mat_var
+    square_int_mat_var
+    square_bin_mat_var
 
 Datasets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -49,7 +49,7 @@ Filtering
 
 Docplex
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. _filtering_api:
+.. _docplex_api:
 .. currentmodule:: pyriemann_qiskit.utils.docplex
 
 .. autosummary::

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,3 +13,4 @@ qiskit-ibmq-provider==0.19.1
 scipy==1.7.3
 moabb>=0.4.6
 git+https://github.com/pyRiemann/pyRiemann#egg=pyriemann
+docplex

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -1,6 +1,9 @@
-from . import hyper_params_factory, filtering
+from . import hyper_params_factory, filtering, covmat_cont_var, covmat_int_var, covmat_bin_var
 
 __all__ = [
     'hyper_params_factory',
-    'filtering'
+    'filtering',
+    'covmat_cont_var',
+    'covmat_int_var',
+    'covmat_bin_var'
 ]

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -1,9 +1,13 @@
-from . import hyper_params_factory, filtering, covmat_cont_var, covmat_int_var, covmat_bin_var
+from . import (hyper_params_factory,
+               filtering,
+               square_cont_mat_var,
+               square_int_mat_var,
+               square_bin_mat_var)
 
 __all__ = [
     'hyper_params_factory',
     'filtering',
-    'covmat_cont_var',
-    'covmat_int_var',
-    'covmat_bin_var'
+    'square_cont_mat_var',
+    'square_int_mat_var',
+    'square_bin_mat_var'
 ]

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -1,8 +1,8 @@
 from . import (hyper_params_factory,
-               filtering,
-               square_cont_mat_var,
-               square_int_mat_var,
-               square_bin_mat_var)
+               filtering)
+from .docplex import (square_cont_mat_var,
+                      square_int_mat_var,
+                      square_bin_mat_var)
 
 __all__ = [
     'hyper_params_factory',

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -1,5 +1,4 @@
-from . import (hyper_params_factory,
-               filtering)
+from . import hyper_params_factory, filtering
 from .docplex import (square_cont_mat_var,
                       square_int_mat_var,
                       square_bin_mat_var)

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -19,8 +19,10 @@ def square_cont_mat_var(prob, channels,
 
     Returns
     -------
-    covmat : dict
+    square_mat : dict
         A square matrix of continuous decision variables.
+        Access element (i, j) with square_mat[(i, j)].
+        Indices start with 0.
 
     References
     ----------
@@ -50,8 +52,10 @@ def square_int_mat_var(prob, channels,
 
     Returns
     -------
-    covmat : dict
+    square_mat : dict
         A square matrix of integer decision variables.
+        Access element (i, j) with square_mat[(i, j)].
+        Indices start with 0.
 
     References
     ----------
@@ -81,8 +85,10 @@ def square_bin_mat_var(prob, channels,
 
     Returns
     -------
-    covmat : dict
+    square_mat : dict
         A square matrix of binary decision variables.
+        Access element (i, j) with square_mat[(i, j)].
+        Indices start with 0.
 
     References
     ----------
@@ -91,4 +97,4 @@ def square_bin_mat_var(prob, channels,
     """
     BinaryVarType.one_letter_symbol = lambda _: 'B'
     return prob.binary_var_matrix(keys1=channels, keys2=channels,
-                                  name=name, lb=-prob.infinity)
+                                  name=name)

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -1,17 +1,94 @@
 from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
 
 
-def covmat_cont_var(prob, channels, name='cont_covmat'):
+def square_cont_mat_var(prob, channels,
+                        name='cont_covmat'):
+    """Creates a 2-dimensional dictionary of continuous decision variables,
+    indexed by pairs of key objects.
+    The dictionary represents a square matrix of size
+    len(channels) x len(channels).
+    A key can be any Python object, with the exception of None.
+
+    Parameters
+    ----------
+    prob : Model
+        An instance of the docplex model [1]_
+    channels : list
+        The list of channels. A channel can be any Python object,
+        such as channels'name or number but None.
+
+    Returns
+    -------
+    covmat : dict
+        A square matrix of continuous decision variables.
+
+    References
+    ----------
+    .. [1] \
+        http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
+    """
     ContinuousVarType.one_letter_symbol = lambda _: 'C'
     return prob.continuous_var_matrix(keys1=channels, keys2=channels,
                                       name=name, lb=-prob.infinity)
 
-def covmat_int_var(prob, channels, name='int_covmat'):
+
+def square_int_mat_var(prob, channels,
+                       name='int_covmat'):
+    """Creates a 2-dimensional dictionary of integer decision variables,
+    indexed by pairs of key objects.
+    The dictionary represents a square matrix of size
+    len(channels) x len(channels).
+    A key can be any Python object, with the exception of None.
+
+    Parameters
+    ----------
+    prob : Model
+        An instance of the docplex model [1]_
+    channels : list
+        The list of channels. A channel can be any Python object,
+        such as channels'name or number but None.
+
+    Returns
+    -------
+    covmat : dict
+        A square matrix of integer decision variables.
+
+    References
+    ----------
+    .. [1] \
+        http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
+    """
     IntegerVarType.one_letter_symbol = lambda _: 'I'
     return prob.integer_var_matrix(keys1=channels, keys2=channels,
                                    name=name, lb=-prob.infinity)
 
-def covmat_bin_var(prob, channels, name='bin_covmat'):
+
+def square_bin_mat_var(prob, channels,
+                       name='bin_covmat'):
+    """Creates a 2-dimensional dictionary of binary decision variables,
+    indexed by pairs of key objects.
+    The dictionary represents a square matrix of size
+    len(channels) x len(channels).
+    A key can be any Python object, with the exception of None.
+
+    Parameters
+    ----------
+    prob : Model
+        An instance of the docplex model [1]_
+    channels : list
+        The list of channels. A channel can be any Python object,
+        such as channels'name or number but None.
+
+    Returns
+    -------
+    covmat : dict
+        A square matrix of binary decision variables.
+
+    References
+    ----------
+    .. [1] \
+        http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
+    """
     BinaryVarType.one_letter_symbol = lambda _: 'B'
     return prob.binary_var_matrix(keys1=channels, keys2=channels,
-                                   name=name, lb=-prob.infinity)
+                                  name=name, lb=-prob.infinity)

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -1,0 +1,17 @@
+from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
+
+
+def covmat_cont_var(prob, channels, name='cont_covmat'):
+    ContinuousVarType.one_letter_symbol = lambda _: 'C'
+    return prob.continuous_var_matrix(keys1=channels, keys2=channels,
+                                      name=name, lb=-prob.infinity)
+
+def covmat_int_var(prob, channels, name='int_covmat'):
+    IntegerVarType.one_letter_symbol = lambda _: 'I'
+    return prob.integer_var_matrix(keys1=channels, keys2=channels,
+                                   name=name, lb=-prob.infinity)
+
+def covmat_bin_var(prob, channels, name='bin_covmat'):
+    BinaryVarType.one_letter_symbol = lambda _: 'B'
+    return prob.binary_var_matrix(keys1=channels, keys2=channels,
+                                   name=name, lb=-prob.infinity)

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -1,9 +1,10 @@
-from pyriemann_qiskit.utils.docplex import covmat_cont_var, covmat_int_var, covmat_bin_var
+from pyriemann_qiskit.utils.docplex import square_cont_mat_var
 from docplex.mp.model import Model
 
 
 def test_get_square_cont_var():
     channels = range(4)
     prob = Model()
-    mat = covmat_cont_var(prob, channels, name='test')
+    mat = square_cont_mat_var(prob, channels, name='test')
+    # check len and type
     assert mat is not None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -1,8 +1,10 @@
-from pyriemann_qiskit.utils.docplex import square_bin_mat_var, square_int_mat_var
 import pytest
-from pyriemann_qiskit.utils import square_cont_mat_var, square_int_mat_var, square_bin_mat_var
 from docplex.mp.model import Model
 from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
+from pyriemann_qiskit.utils import (square_cont_mat_var,
+                                    square_int_mat_var,
+                                    square_bin_mat_var)
+
 
 @pytest.mark.parametrize('square_mat_var',
                          [(square_cont_mat_var, ContinuousVarType),

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -1,11 +1,9 @@
-from docplex.mp.vartype import ContinuousVarType
+from pyriemann_qiskit.utils.docplex import covmat_cont_var, covmat_int_var, covmat_bin_var
 from docplex.mp.model import Model
 
 
 def test_get_square_cont_var():
     channels = range(4)
     prob = Model()
-    ContinuousVarType.one_letter_symbol = lambda _: 'C'
-    mat = prob.continuous_var_matrix(keys1=channels, keys2=channels,
-                                     name='test', lb=-prob.infinity)
+    mat = covmat_cont_var(prob, channels, name='test')
     assert mat is not None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -1,10 +1,20 @@
-from pyriemann_qiskit.utils.docplex import square_cont_mat_var
+from pyriemann_qiskit.utils.docplex import square_bin_mat_var, square_int_mat_var
+import pytest
+from pyriemann_qiskit.utils import square_cont_mat_var, square_int_mat_var, square_bin_mat_var
 from docplex.mp.model import Model
+from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
 
-
-def test_get_square_cont_var():
-    channels = range(4)
+@pytest.mark.parametrize('square_mat_var',
+                         [(square_cont_mat_var, ContinuousVarType),
+                          (square_int_mat_var, IntegerVarType),
+                          (square_bin_mat_var, BinaryVarType)])
+def test_get_square_cont_var(square_mat_var):
+    n = 4
+    channels = range(n)
     prob = Model()
-    mat = square_cont_mat_var(prob, channels, name='test')
-    # check len and type
-    assert mat is not None
+    handle = square_mat_var[0]
+    expected_result_type = square_mat_var[1]
+    mat = handle(prob, channels, name='test')
+    first_element = mat[(0, 0)]
+    assert len(mat) == n * n
+    assert type(first_element.vartype) is expected_result_type


### PR DESCRIPTION
Implements #28.
The PR introduces helper methods to generate covariance matrix variables for optimization problems.
This is a pre-request to build a custom optimizer we could use to run a version of the MDM algorithm rewritten with the constraint programming paradigm. 
We do this because quantum optimization algorithms in Qiskit accepts optimization problem written in docplex as possible input. 
