### PR TITLE
Update test_utils_firebase.py

### DIFF
--- a/tests/test_utils_firebase.py
+++ b/tests/test_utils_firebase.py
@@ -6,6 +6,11 @@ from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC
 
 
+def test_firebase_connection():
+    # Should retrieve correct certificate
+    assert not FirebaseConnector() is None
+
+
 def test_firebase_connector():
     mock_data = {
         'dataset1': {


### PR DESCRIPTION
Follow-up for #63.

I reintroduce in this PR the connection test that was disabled in #82 due to an unsafe context. Indeed, the base branch was in a forked repository and therefore it was unable to access this repo secret for connecting to firebase.

The main difference is that the base branch for this PR is nested inside `pyRiemann-qiskit` itself and not a forked repo.