### PR TITLE
Fix deprecated api method in sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -332,4 +332,4 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 def setup(app):
     app.add_js_file('copybutton.js')
-    app.add_stylesheet('style.css')
+    app.add_css_file('style.css')


### PR DESCRIPTION
As per https://github.com/sphinx-doc/sphinx/issues/7747, the method `add_stylesheet` was deprecated and now removed from Spinx. It is replaced by `add_css_file`