### PR TITLE
fix/firebase admin could not load due to google cloud dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+FROM python:3.8-slim-buster
+ADD pyriemann_qiskit /pyriemann_qiskit
+ADD examples /examples
+ADD setup.py /
+ADD README.md /
+
+RUN apt-get update
+RUN apt-get -y install git
+
+RUN apt-get --allow-releaseinfo-change update
+RUN python -m pip install --upgrade pip
+RUN apt-get -y install --fix-missing git-core
+RUN apt-get -y install build-essential
+
 RUN pip install urllib3==1.26.12
 RUN python setup.py develop
 RUN pip install .[docs]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ RUN mkdir /home/mne_data
 ### Missing __init__ file in protobuf
 RUN touch /usr/local/lib/python3.8/site-packages/protobuf-4.22.1-py3.8-linux-x86_64.egg/google/__init__.py
 ## google.cloud.location is never used in these files, and is missing in path.
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/client.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/rest.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/async_client.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/client.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/rest.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/async_client.py'
 
 ENTRYPOINT [ "python", "/examples/ERP/classify_P300_bi.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,21 @@
-FROM python:3.8-slim-buster
-ADD pyriemann_qiskit /pyriemann_qiskit
-ADD examples /examples
-ADD setup.py /
-ADD README.md /
-
-RUN apt-get update
-RUN apt-get -y install git
-
-RUN apt-get --allow-releaseinfo-change update
-RUN python -m pip install --upgrade pip
-RUN apt-get -y install --fix-missing git-core
-RUN apt-get -y install build-essential
-
 RUN pip install urllib3==1.26.12
 RUN python setup.py develop
 RUN pip install .[docs]
+RUN pip install .[tests]
 
 ## Creating folders for mne data
 RUN mkdir /root/mne_data
 RUN mkdir /home/mne_data
+
+## Workaround for firestore
+### Missing __init__ file in protobuf
+RUN touch /usr/local/lib/python3.8/site-packages/protobuf-4.22.1-py3.8-linux-x86_64.egg/google/__init__.py
+## google.cloud.location is never used in these files, and is missing in path.
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/client.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/rest.py'
+RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/async_client.py'
 
 ENTRYPOINT [ "python", "/examples/ERP/classify_P300_bi.py" ]

--- a/README.md
+++ b/README.md
@@ -176,3 +176,23 @@ There is a known issue when you install `pyRiemann-qiskit` in an environement wh
 pip uninstall pyriemann
 pip install pyriemann@git+https://github.com/pyRiemann/pyRiemann#egg=pyriemann
 ```
+
+## Firebase admin not loading
+In some environment, the firebase admin module is not loaded. There is two reasons:
+1) The protobuf package is missing an `__init__.py` file. You can fix this issue by adding it manually as it is done in the DockerFile:
+
+```
+touch /usr/local/lib/python3.8/site-packages/protobuf-4.22.1-py3.8-linux-x86_64.egg/google/__init__.py
+```
+
+2) The Firestore service contains unused dependency to `google.cloud.location`. You can fix this issue by removing the dependencies manually,
+as it is done in the DockerFile too:
+
+```
+sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/client.py'
+sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'
+sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc.py'
+sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py'
+sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/rest.py'
+sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.10.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/async_client.py'
+```


### PR DESCRIPTION
This PR fixes a dependency issue that forbids firebase_admin to run on certain environments.
The DockerFile was updated as well as the troubleshooting section.
