### PR TITLE
Complete example with Firebase cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir /home/mne_data
 
 ## Workaround for firestore
 ### Missing __init__ file in protobuf
-RUN touch /usr/local/lib/python3.8/site-packages/protobuf-4.22.1-py3.8-linux-x86_64.egg/google/__init__.py
+RUN touch /usr/local/lib/python3.8/site-packages/protobuf-4.22.3-py3.8-linux-x86_64.egg/google/__init__.py
 ## google.cloud.location is never used in these files, and is missing in path.
 RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/client.py'
 RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.0-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -94,7 +94,7 @@ Firebase
     FirebaseConnector
     Cache
     generate_caches
-    filter_subjects_with_all_results
+    filter_subjects_by_incomplete_results
     add_moabb_dataframe_results_to_caches
     convert_caches_to_dataframes
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,6 +37,11 @@ pyRiemann-qiskit: Qiskit wrapper for pyRiemann
            <img src="_images/sphx_glr_classify_P300_bi_thumb.png">
          </div>
        </a>
+       <a href="auto_examples/ERP/firebase_moabb.html">
+         <div class="col-md-3 thumbnail">
+           <img src="_images/sphx_glr_firebase_moabb_thumb.png">
+         </div>
+       </a>
        <a href="auto_examples/ERP/compare_dim_red.html">
          <div class="col-md-3 thumbnail">
            <img src="_images/sphx_glr_compare_dim_red_thumb.png">

--- a/examples/ERP/firebase_moabb.py
+++ b/examples/ERP/firebase_moabb.py
@@ -26,7 +26,7 @@ from pyriemann.estimation import XdawnCovariances
 from pyriemann.tangentspace import TangentSpace
 from pyriemann_qiskit.utils import (
         generate_caches,
-        filter_subjects_with_all_results,
+        filter_subjects_by_incomplete_results,
         add_moabb_dataframe_results_to_caches,
         convert_caches_to_dataframes
     )
@@ -119,7 +119,7 @@ caches = generate_caches(datasets, pipelines)
 # This method remove a subject in a dataset if we already have evaluated
 # all pipelines for this subject.
 # Therefore we will use a copy of the original datasets.
-filter_subjects_with_all_results(caches, copy_datasets, pipelines)
+filter_subjects_by_incomplete_results(caches, copy_datasets, pipelines)
 
 print("Total pipelines to evaluate: ", len(pipelines))
 print("Subjects to evaluate",

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -9,7 +9,7 @@ from .firebase_connector import (
         FirebaseConnector,
         Cache,
         generate_caches,
-        filter_subjects_with_all_results,
+        filter_subjects_by_incomplete_results,
         add_moabb_dataframe_results_to_caches,
         convert_caches_to_dataframes
     )
@@ -26,7 +26,7 @@ __all__ = [
     'FirebaseConnector',
     'Cache',
     'generate_caches',
-    'filter_subjects_with_all_results',
+    'filter_subjects_by_incomplete_results',
     'add_moabb_dataframe_results_to_caches',
     'convert_caches_to_dataframes'
 ]

--- a/pyriemann_qiskit/utils/firebase_connector.py
+++ b/pyriemann_qiskit/utils/firebase_connector.py
@@ -280,7 +280,7 @@ def generate_caches(datasets: list, pipelines: list, mock_data=None):
     return caches
 
 
-def filter_subjects_with_all_results(caches, datasets: list,
+def filter_subjects_by_incomplete_results(caches, datasets: list,
                                      pipelines: list):
     """
     Keep only subjects with incomplete results in the datasets

--- a/pyriemann_qiskit/utils/firebase_connector.py
+++ b/pyriemann_qiskit/utils/firebase_connector.py
@@ -281,7 +281,7 @@ def generate_caches(datasets: list, pipelines: list, mock_data=None):
 
 
 def filter_subjects_by_incomplete_results(caches, datasets: list,
-                                     pipelines: list):
+                                          pipelines: list):
     """
     Keep only subjects with incomplete results in the datasets
     (that is results for at least one pipeline is missing).

--- a/pyriemann_qiskit/utils/firebase_connector.py
+++ b/pyriemann_qiskit/utils/firebase_connector.py
@@ -285,6 +285,7 @@ def filter_subjects_with_all_results(caches, datasets: list,
     """
     Keep only subjects with incomplete results in the datasets
     (that is results for at least one pipeline is missing).
+    The subject list of the datasets is modified by this function.
 
     Parameters
     ----------


### PR DESCRIPTION
Issue #84 
This PR completed the example with MOABB and ERP classification.
It demonstrates how we can use Firebase admin to synchronize MOABB results.
A simple use case is to split the number of subjects in a dataset between two computers.
Then the two MOABB evaluations are run in parallel and the results are synchronized on the Firebase server.
It is also useful when we want to store and retrieve the results of past computation on a same computer.

@toncho11 FYI