### PR TITLE
Quantic mdm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN mkdir /root/mne_data
 RUN mkdir /home/mne_data
 
 ## Workaround for firestore
-RUN pip install protobuf==4.23.1
+RUN pip install protobuf==4.23.2
 RUN pip install google_cloud_firestore==2.11.1
 ### Missing __init__ file in protobuf
-RUN touch /usr/local/lib/python3.8/site-packages/protobuf-4.23.1-py3.8.egg/google/__init__.py
+RUN touch /usr/local/lib/python3.8/site-packages/protobuf-4.23.2-py3.8.egg/google/__init__.py
 ## google.cloud.location is never used in these files, and is missing in path.
 RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/client.py'
 RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.8/site-packages/google_cloud_firestore-2.11.1-py3.8.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -84,6 +84,8 @@ Docplex
     pyQiskitOptimizer
     ClassicalOptimizer
     NaiveQAOAOptimizer
+    set_global_optimizer
+    get_global_optimizer
 
 Math
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -73,6 +73,7 @@ Docplex
     pyQiskitOptimizer
     ClassicalOptimizer
     NaiveQAOAOptimizer
+    mdm
 
 Math
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -16,6 +16,7 @@ Classification
     QuanticClassifierBase
     QuanticSVM
     QuanticVQC
+    QuanticMDM
     QuantumClassifierWithDefaultRiemannianPipeline
 
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -59,6 +59,16 @@ Mean
 
     fro_mean_convex
 
+Distance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _distance_api:
+.. currentmodule:: pyriemann_qiskit.utils.distance
+
+.. autosummary::
+    :toctree: generated/
+
+    logeucl_dist_convex
+
 Docplex
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. _docplex_api:
@@ -73,7 +83,6 @@ Docplex
     pyQiskitOptimizer
     ClassicalOptimizer
     NaiveQAOAOptimizer
-    mdm
 
 Math
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,6 +14,6 @@ qiskit-optimization==0.5.0
 qiskit-aer==0.12.0
 scipy==1.7.3
 moabb>=0.4.6
-git+https://github.com/pyRiemann/pyRiemann#egg=pyriemann
+pyriemann==0.4
 docplex>=2.21.207
 firebase_admin==6.1.0

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -19,11 +19,10 @@ from .utils import get_provider, get_devices
 from pyriemann.estimation import XdawnCovariances
 from pyriemann.classification import MDM
 from pyriemann.tangentspace import TangentSpace
-from pyriemann.utils.mean import mean_logeuclid
 from pyriemann_qiskit.datasets import get_feature_dimension
 from pyriemann_qiskit.utils import (ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
-                                    mdm)
+                                    logeucl_dist_convex)
 
 logger.level = logging.INFO
 
@@ -525,11 +524,13 @@ class QuanticMDM(QuanticClassifierBase):
             self._optimizer = NaiveQAOAOptimizer()
         else:
             self._optimizer = ClassicalOptimizer()
-        def predict_distances(instance, X):
+        def predict_distances(X):
+            # if metric == convex
+            # and also erase transform
             print("X+shape", X.shape)
-            return np.array([mdm(np.array(instance.covmeans_), x) for x in X])
+            return np.array([logeucl_dist_convex(np.array(classifier.covmeans_), x) for x in X])
 
-        MDM._predict_distances = predict_distances
+        classifier._predict_distances = predict_distances
         return classifier
 
     def predict_proba(self, X):

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -519,8 +519,8 @@ class QuanticMDM(QuanticClassifierBase):
         self._log("Convex MDM initiating algorithm")
         classifier = MDM(metric=self.metric)
         if self.quantum:
-            # TODO: support execution on remote backedn
-            self._optimizer = NaiveQAOAOptimizer()
+            self._optimizer = \
+                NaiveQAOAOptimizer(quantum_instance = self._quantum_instance)
         else:
             self._optimizer = ClassicalOptimizer()
         return classifier

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -524,13 +524,6 @@ class QuanticMDM(QuanticClassifierBase):
             self._optimizer = NaiveQAOAOptimizer()
         else:
             self._optimizer = ClassicalOptimizer()
-        def predict_distances(X):
-            # if metric == convex
-            # and also erase transform
-            print("X+shape", X.shape)
-            return np.array([logeucl_dist_convex(np.array(classifier.covmeans_), x) for x in X])
-
-        classifier._predict_distances = predict_distances
         return classifier
 
     def predict_proba(self, X):

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -518,7 +518,9 @@ class QuanticMDM(QuanticClassifierBase):
         (LVA/ICA 2010), LNCS vol. 6365, 2010, p. 629-636.
     """
 
-    def __init__(self, metric={"mean":'logeuclid', "distance": 'convex'}, **parameters):
+    def __init__(self,
+                 metric={"mean": 'logeuclid', "distance": 'convex'},
+                 **parameters):
         QuanticClassifierBase.__init__(self, **parameters)
         self.metric = metric
 

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -490,7 +490,7 @@ class QuanticMDM(QuanticClassifierBase):
 
     Parameters
     ----------
-    metric : string | dict, default='riemann'
+    metric : string | dict, default={"mean": 'logeuclid', "distance": 'convex'}
         The type of metric used for centroid and distance estimation.
         see `mean_covariance` for the list of supported metric.
         the metric could be a dict with two keys, `mean` and `distance` in

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -17,6 +17,7 @@ from .utils.hyper_params_factory import (gen_zz_feature_map,
                                          get_spsa)
 from .utils import get_provider, get_devices
 from pyriemann.estimation import XdawnCovariances
+from pyriemann.classification import MDM
 from pyriemann.tangentspace import TangentSpace
 from pyriemann_qiskit.datasets import get_feature_dimension
 
@@ -473,35 +474,18 @@ class QuanticVQC(QuanticClassifierBase):
 
 class QuanticMDM(QuanticClassifierBase):
 
-    """Quantum-enhanced SVM classification.
+    """Quantum-enhanced MDM
 
-    This class implements SVC [1]_ on a quantum machine [2]_.
-    Note that if `quantum` parameter is set to `False`
-    then a classical SVC will be perfomed instead.
+    This class is a quantum implementation of the MDM [1]_.
 
     Notes
     -----
-    .. versionadded:: 0.0.1
-    .. versionchanged:: 0.0.2
-       Qiskit's Pegasos implementation [4, 5]_.
+    .. versionadded:: 0.0.4
 
     Parameters
     ----------
-    gamma : float | None (default: None)
-        Used as input for sklearn rbf_kernel which is used internally.
-        See [3]_ for more information about gamma.
-    C : float (default: 1.0)
-        Regularization parameter. The strength of the regularization is
-        inversely proportional to C. Must be strictly positive.
-        Note, if pegasos is enabled you may want to consider
-        larger values of C.
-    max_iter: int | None (default: None)
-        number of steps in Pegasos or (Q)SVC.
-        If None, respective default values for Pegasos and SVC
-        are used. The default value for Pegasos is 1000.
-        For (Q)SVC it is -1 (that is not limit).
-    pegasos : boolean (default: False)
-        If true, uses Qiskit's PegasosQSVC instead of QSVC.
+    placeholder : bool (default: True)
+        Placeholder parameter
 
     See Also
     --------
@@ -509,68 +493,38 @@ class QuanticMDM(QuanticClassifierBase):
 
     References
     ----------
-    .. [1] Available from: \
-        https://scikit-learn.org/stable/modules/generated/sklearn.svm.SVC.html
-
-    .. [2] V. Havlíček et al.,
-           ‘Supervised learning with quantum-enhanced feature spaces’,
-           Nature, vol. 567, no. 7747, pp. 209–212, Mar. 2019,
-           doi: 10.1038/s41586-019-0980-2.
-
-    .. [3] Available from: \
-        https://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.rbf_kernel.html
-
-    .. [4] G. Gentinetta, A. Thomsen, D. Sutter, and S. Woerner,
-           ‘The complexity of quantum support vector machines’, arXiv,
-           arXiv:2203.00031, Feb. 2022.
-           doi: 10.48550/arXiv.2203.00031
-
-    .. [5] S. Shalev-Shwartz, Y. Singer, and A. Cotter,
-           ‘Pegasos: Primal Estimated sub-GrAdient SOlver for SVM’
-
+    .. [1] `Multiclass Brain-Computer Interface Classification by Riemannian
+        Geometry
+        <https://hal.archives-ouvertes.fr/hal-00681328>`_
+        A. Barachant, S. Bonnet, M. Congedo, and C. Jutten. IEEE Transactions
+        on Biomedical Engineering, vol. 59, no. 4, p. 920-928, 2012.
+    .. [2] `Riemannian geometry applied to BCI classification
+        <https://hal.archives-ouvertes.fr/hal-00602700/>`_
+        A. Barachant, S. Bonnet, M. Congedo and C. Jutten. 9th International
+        Conference Latent Variable Analysis and Signal Separation
+        (LVA/ICA 2010), LNCS vol. 6365, 2010, p. 629-636.
     """
 
-    def __init__(self, gamma='scale', C=1.0, max_iter=None,
-                 pegasos=False, **parameters):
+    def __init__(self, placeholder, **parameters):
         QuanticClassifierBase.__init__(self, **parameters)
-        self.gamma = gamma
-        self.C = C
-        self.max_iter = max_iter
-        self.pegasos = pegasos
+        self.placeholder = placeholder
 
     def _init_algo(self, n_features):
         self._log("SVM initiating algorithm")
         if self.quantum:
-            quantum_kernel = \
-                QuantumKernel(feature_map=self._feature_map,
-                              quantum_instance=self._quantum_instance)
-            if self.pegasos:
-                self._log("[Warning] `gamma` is not supported by PegasosQSVC")
-                num_steps = 1000 if self.max_iter is None else self.max_iter
-                classifier = PegasosQSVC(quantum_kernel=quantum_kernel,
-                                         C=self.C,
-                                         num_steps=num_steps)
-            else:
-                max_iter = -1 if self.max_iter is None else self.max_iter
-                classifier = QSVC(quantum_kernel=quantum_kernel,
-                                  gamma=self.gamma, C=self.C,
-                                  max_iter=max_iter)
+            self._log("[Warning] Quantum not implemented yet. Disabling.")
+            classifier = MDM()
         else:
-            max_iter = -1 if self.max_iter is None else self.max_iter
-            classifier = SVC(gamma=self.gamma, C=self.C, max_iter=max_iter)
+            classifier = MDM()
         return classifier
 
     def predict_proba(self, X):
-        """This method is implemented for compatibility purpose
-           as SVM prediction probabilities are not available.
-           This method assigns a boolean value to each trial which
-           depends on whether the label was assigned to class 0 or 1
+        """Return the probabilities associated with predictions.
 
         Parameters
         ----------
-        X : ndarray, shape (n_samples, n_features)
-            Input vector, where `n_samples` is the number of samples and
-            `n_features` is the number of features.
+        X : ndarray, shape (n_trials, n_channels, n_times)
+            ndarray of trials.
 
         Returns
         -------
@@ -578,10 +532,8 @@ class QuanticMDM(QuanticClassifierBase):
             prob[n, 0] == True if the nth sample is assigned to 1st class;
             prob[n, 1] == True if the nth sample is assigned to 2nd class.
         """
-        predicted_labels = self.predict(X)
-        ret = [np.array([c == self.classes_[0], c == self.classes_[1]])
-               for c in predicted_labels]
-        return np.array(ret)
+
+        return self._classifier.predict_proba(X)
 
     def predict(self, X):
         """Calculates the predictions.

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -21,7 +21,6 @@ from pyriemann.tangentspace import TangentSpace
 from pyriemann_qiskit.datasets import get_feature_dimension
 from pyriemann_qiskit.utils import (ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
-                                    logeucl_dist_convex,
                                     set_global_optimizer)
 
 logger.level = logging.INFO
@@ -479,10 +478,10 @@ class QuanticMDM(QuanticClassifierBase):
 
     """Quantum-enhanced MDM
 
-    # This class is a convex implementation of the MDM [1]_, 
+    # This class is a convex implementation of the MDM [1]_,
     # that can runs with quantum optimization.
     # Only log-euclidian distance between trial and class prototypes
-    # is supported at the moment, but any type of metric 
+    # is supported at the moment, but any type of metric
     # can be used for centroid estimation.
 
     Notes
@@ -528,7 +527,7 @@ class QuanticMDM(QuanticClassifierBase):
         classifier = MDM(metric=self.metric)
         if self.quantum:
             self._optimizer = \
-                NaiveQAOAOptimizer(quantum_instance = self._quantum_instance)
+                NaiveQAOAOptimizer(quantum_instance=self._quantum_instance)
         else:
             self._optimizer = ClassicalOptimizer()
         set_global_optimizer(self._optimizer)

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -21,7 +21,8 @@ from pyriemann.tangentspace import TangentSpace
 from pyriemann_qiskit.datasets import get_feature_dimension
 from pyriemann_qiskit.utils import (ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
-                                    logeucl_dist_convex)
+                                    logeucl_dist_convex,
+                                    set_global_optimizer)
 
 logger.level = logging.INFO
 
@@ -530,6 +531,7 @@ class QuanticMDM(QuanticClassifierBase):
                 NaiveQAOAOptimizer(quantum_instance = self._quantum_instance)
         else:
             self._optimizer = ClassicalOptimizer()
+        set_global_optimizer(self._optimizer)
         return classifier
 
     def predict_proba(self, X):

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -505,7 +505,7 @@ class QuanticMDM(QuanticClassifierBase):
         (LVA/ICA 2010), LNCS vol. 6365, 2010, p. 629-636.
     """
 
-    def __init__(self, placeholder, **parameters):
+    def __init__(self, placeholder=False, **parameters):
         QuanticClassifierBase.__init__(self, **parameters)
         self.placeholder = placeholder
 

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -490,12 +490,19 @@ class QuanticMDM(QuanticClassifierBase):
 
     Parameters
     ----------
-    metric : string | dic (default: 'logeuclid')
-        TODO
+    metric : string | dict, default='riemann'
+        The type of metric used for centroid and distance estimation.
+        see `mean_covariance` for the list of supported metric.
+        the metric could be a dict with two keys, `mean` and `distance` in
+        order to pass different metrics for the centroid estimation and the
+        distance estimation. Typical usecase is to pass 'logeuclid' metric for
+        the mean in order to boost the computional speed and 'riemann' for the
+        distance in order to keep the good sensitivity for the classification.
 
     See Also
     --------
     QuanticClassifierBase
+    pyriemann.classification.MDM
 
     References
     ----------

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -7,7 +7,9 @@ from .docplex import (square_cont_mat_var,
                       square_int_mat_var,
                       square_bin_mat_var,
                       ClassicalOptimizer,
-                      NaiveQAOAOptimizer)
+                      NaiveQAOAOptimizer,
+                      set_global_optimizer,
+                      get_global_optimizer)
 from .firebase_connector import (
         FirebaseConnector,
         Cache,

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -32,6 +32,8 @@ __all__ = [
     'square_bin_mat_var',
     'ClassicalOptimizer',
     'NaiveQAOAOptimizer',
+    'set_global_optimizer',
+    'get_global_optimizer',
     'logeucl_dist_convex',
     'FirebaseConnector',
     'Cache',

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -6,8 +6,7 @@ from .docplex import (square_cont_mat_var,
                       square_int_mat_var,
                       square_bin_mat_var,
                       ClassicalOptimizer,
-                      NaiveQAOAOptimizer,
-                      mdm)
+                      NaiveQAOAOptimizer)
 from .firebase_connector import (
         FirebaseConnector,
         Cache,
@@ -16,6 +15,7 @@ from .firebase_connector import (
         add_moabb_dataframe_results_to_caches,
         convert_caches_to_dataframes
     )
+from .distance import logeucl_dist_convex
 
 __all__ = [
     'hyper_params_factory',
@@ -28,7 +28,7 @@ __all__ = [
     'square_bin_mat_var',
     'ClassicalOptimizer',
     'NaiveQAOAOptimizer',
-    'mdm',
+    'logeucl_dist_convex',
     'FirebaseConnector',
     'Cache',
     'generate_caches',

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -6,7 +6,8 @@ from .docplex import (square_cont_mat_var,
                       square_int_mat_var,
                       square_bin_mat_var,
                       ClassicalOptimizer,
-                      NaiveQAOAOptimizer)
+                      NaiveQAOAOptimizer,
+                      mdm)
 from .firebase_connector import (
         FirebaseConnector,
         Cache,
@@ -27,6 +28,7 @@ __all__ = [
     'square_bin_mat_var',
     'ClassicalOptimizer',
     'NaiveQAOAOptimizer',
+    'mdm',
     'FirebaseConnector',
     'Cache',
     'generate_caches',

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -4,7 +4,6 @@ from pyriemann_qiskit.utils.docplex import (ClassicalOptimizer,
                                             get_global_optimizer)
 from pyriemann.classification import MDM
 from pyriemann.utils.distance import (distance_logeuclid,
-                                      logm,
                                       distance_methods,
                                       distance)
 

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -4,8 +4,7 @@ from pyriemann_qiskit.utils.docplex import (ClassicalOptimizer,
                                             get_global_optimizer)
 from pyriemann.classification import MDM
 from pyriemann.utils.distance import (distance_logeuclid,
-                                      distance_methods,
-                                      distance)
+                                      distance_methods)
 
 
 def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -1,8 +1,11 @@
 import numpy as np
 from docplex.mp.model import Model
 from pyriemann_qiskit.utils.docplex import ClassicalOptimizer
-from pyriemann.utils.distance import distance_methods
-from pyriemann.utils.distance import distance_logeuclid
+from pyriemann.classification import MDM
+from pyriemann.utils.distance import (distance_logeuclid,
+                                      distance_methods,
+                                      distance)
+
 
 def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):
     """Convex formulation of the MDM algorithm
@@ -57,5 +60,21 @@ def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):
 
     return result
 
+_mdm_predict_distances_original = MDM._predict_distances
 
-# distance_methods['convex'] = cvx_distance
+def predict_distances(mdm, X):
+    if mdm.metric_dist == 'convex':
+        centroids = np.array(mdm.covmeans_)
+        return np.array([logeucl_dist_convex(centroids, x) for x in X])
+        return np.array([distance(centroids, x, mdm.metric_dist) for x in X])
+    else:
+        return _mdm_predict_distances_original(mdm, X)
+
+MDM._predict_distances = predict_distances
+
+# This is only for validation inside the MDM.
+# In fact, we override the _predict_distances method
+# inside MDM to directly use logeucl_dist_convex when the metric is "convex"
+# This is due to the fact the the signature of this method is different from
+# the usual distance functions.
+distance_methods['convex'] = logeucl_dist_convex

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -64,7 +64,9 @@ def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):
 
     return result
 
+
 _mdm_predict_distances_original = MDM._predict_distances
+
 
 def predict_distances(mdm, X):
     if mdm.metric_dist == 'convex':
@@ -72,6 +74,7 @@ def predict_distances(mdm, X):
         return np.array([logeucl_dist_convex(centroids, x) for x in X])
     else:
         return _mdm_predict_distances_original(mdm, X)
+
 
 MDM._predict_distances = predict_distances
 

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -1,0 +1,61 @@
+import numpy as np
+from docplex.mp.model import Model
+from pyriemann_qiskit.utils.docplex import ClassicalOptimizer
+from pyriemann.utils.distance import distance_methods
+from pyriemann.utils.distance import distance_logeuclid
+
+def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):
+    """Convex formulation of the MDM algorithm
+    with log-euclidian metric.
+
+    Parameters
+    ----------
+    X : ndarray, shape (n_classes, n_channels, n_channels)
+        Set of SPD matrices.
+    y : ndarray, shape (n_channels, n_channels)
+        A trial
+
+    Returns
+    -------
+    weights : ndarray, shape (n_classes,)
+        The weights associated with each class.
+        Higher the weight, closer it is to the class prototype.
+        Weights are not normalized.
+
+    Notes
+    -----
+    .. versionadded:: 0.0.4
+
+    References
+    ----------
+    .. [1] \
+        http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
+
+    """
+    n_classes, _, _ = X.shape
+    classes = range(n_classes)
+
+    def dist(m1, m2): 
+        return distance_logeuclid(m1, m2)
+
+    prob = Model()
+
+    # should be part of the optimizer
+    w = prob.continuous_var_matrix(keys1=[1], keys2=classes,
+                                   name="weight", lb=0, ub=1)
+    w = np.array([w[key] for key in w])
+
+    _2VecLogYD = 2 * prob.sum(w[i]*dist(y, X[i]) for i in classes)
+
+    wtDw = prob.sum(w[i]*w[j]*dist(X[i], X[j]) for i in classes for j in classes)
+
+    objectives = wtDw - _2VecLogYD
+
+    prob.set_objective("min", objectives)
+
+    result = optimizer.solve(prob, reshape=False)
+
+    return result
+
+
+# distance_methods['convex'] = cvx_distance

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -1,13 +1,12 @@
 import numpy as np
 from docplex.mp.model import Model
-from pyriemann_qiskit.utils.docplex import ClassicalOptimizer, NaiveQAOAOptimizer
+from pyriemann_qiskit.utils.docplex import (ClassicalOptimizer,
+                                            get_global_optimizer)
 from pyriemann.classification import MDM
 from pyriemann.utils.distance import (distance_logeuclid,
                                       logm,
                                       distance_methods,
                                       distance)
-
-_optimizer = None
 
 
 def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):
@@ -39,6 +38,8 @@ def logeucl_dist_convex(X, y, optimizer=ClassicalOptimizer()):
     .. [1] \
         http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
     """
+
+    optimizer = get_global_optimizer(optimizer)
 
     n_classes, _, _ = X.shape
     classes = range(n_classes)

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -427,9 +427,10 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
     n_classes, n_channels, _ = X.shape
     channels = range(n_channels)
 
-    D = [np.flatten(np.log(x)) for x in X]
+    vec = np.ndarray.flatten
+    D = [vec(np.log(x)) for x in X]
 
-    _2VecLogYD = 2 * np.flatten(np.log(y)) * D
+    _2VecLogYD = 2 * vec(np.log(y)) * D
 
     prob = Model()
 

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -8,7 +8,6 @@ It is for example suitable for:
 import math
 import numpy as np
 from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
-from docplex.mp.model import Model
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance
 from qiskit.algorithms import QAOA
@@ -260,7 +259,8 @@ class pyQiskitOptimizer():
 
     """
     def get_weights(self, prob, classes):
-        raise NotImplemented()
+        raise NotImplementedError()
+
 
 class ClassicalOptimizer(pyQiskitOptimizer):
 
@@ -322,7 +322,7 @@ class ClassicalOptimizer(pyQiskitOptimizer):
             n_channels = int(math.sqrt(result.shape[0]))
             return np.reshape(result, (n_channels, n_channels))
         return result
-    
+
     """Helper to create a docplex representation of a
     weight vector.
 
@@ -346,10 +346,11 @@ class ClassicalOptimizer(pyQiskitOptimizer):
     """
     def get_weights(self, prob, classes):
         w = prob.continuous_var_matrix(keys1=[1], keys2=classes,
-                                   name="weight"
-                                , lb=0, ub=1)
+                                       name="weight",
+                                       b=0, ub=1)
         w = np.array([w[key] for key in w])
         return w
+
 
 class NaiveQAOAOptimizer(pyQiskitOptimizer):
 
@@ -472,6 +473,6 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
     """
     def get_weights(self, prob, classes):
         w = prob.integer_var_matrix(keys1=[1], keys2=classes,
-                                   name="weight", lb=0, ub=self.upper_bound)
+                                    name="weight", lb=0, ub=self.upper_bound)
         w = np.array([w[key] for key in w])
         return w

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -17,6 +17,45 @@ from qiskit_optimization.translators import from_docplex_mp
 from pyriemann_qiskit.utils import cov_to_corr_matrix, get_simulator
 
 
+_global_optimizer = None
+
+
+def set_global_optimizer(optimizer):
+    """Set the value of the global optimizer
+
+    Parameters
+    ----------
+    optimizer: pyQiskitOptimizer
+      An instance of pyQiskitOptimizer.
+
+    Notes
+    -----
+    .. versionadded:: 0.0.4
+    """
+    _global_optimizer = optimizer
+
+
+def get_global_optimizer(default):
+    """Get the value of the global optimizer
+
+    Parameters
+    ----------
+    default: pyQiskitOptimizer
+      An instance of pyQiskitOptimizer.
+      It will be returned by default if the global optimizer is None.
+
+    Returns
+    -------
+    optimizer : pyQiskitOptimizer
+        The global optimizer.
+
+    Notes
+    -----
+    .. versionadded:: 0.0.4
+    """
+    return _global_optimizer if _global_optimizer is not None else default
+
+
 def square_cont_mat_var(prob, channels,
                         name='cont_covmat'):
     """Creates a 2-dimensional dictionary of continuous decision variables,

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -17,6 +17,7 @@ from qiskit_optimization.algorithms import (CobylaOptimizer,
 from qiskit_optimization.converters import IntegerToBinary
 from qiskit_optimization.translators import from_docplex_mp
 from pyriemann_qiskit.utils import cov_to_corr_matrix
+from pyriemann.utils.distance import distance_logeuclid
 
 
 def square_cont_mat_var(prob, channels,
@@ -436,8 +437,23 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
     n_classes, n_channels, _ = X.shape
     classes = range(n_classes)
 
+    def vec(m):
+        ret = []
+        for i in range(n_classes):
+            for j in range(n_classes):
+                if i == j:
+                    ret.append(m[i, j])
+                if j > i:
+                    ret.append(np.sqrt(2) * m[i, j])
+        return ret
+
     def f(m1, m2): #distance
-        return np.dot(m1.flatten(), m2.flatten())
+        return distance_logeuclid(m1, m2)
+        lm1 = np.log(m1)
+        lm2 = np.log(m2)
+        print(lm1)
+        print(vec(lm1))
+        return np.dot(logm(lm1), logm(lm2))
 
     prob = Model()
 

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -32,7 +32,7 @@ def set_global_optimizer(optimizer):
     -----
     .. versionadded:: 0.0.4
     """
-    _global_optimizer = optimizer
+    _global_optimizer = optimizer # noqa
 
 
 def get_global_optimizer(default):

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -237,6 +237,8 @@ class pyQiskitOptimizer():
         qp = from_docplex_mp(prob)
         return self._solve_qp(qp, reshape)
 
+    def get_weights(self, prob, classes):
+        raise NotImplemented()
 
 class ClassicalOptimizer(pyQiskitOptimizer):
 
@@ -297,6 +299,13 @@ class ClassicalOptimizer(pyQiskitOptimizer):
             n_channels = int(math.sqrt(result.shape[0]))
             return np.reshape(result, (n_channels, n_channels))
         return result
+    
+    def get_weights(self, prob, classes):
+        w = prob.continuous_var_matrix(keys1=[1], keys2=classes,
+                                   name="weight"
+                                , lb=0, ub=1)
+        w = np.array([w[key] for key in w])
+        return w
 
 class NaiveQAOAOptimizer(pyQiskitOptimizer):
 
@@ -394,3 +403,9 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
             n_channels = int(math.sqrt(result.shape[0]))
             return np.reshape(result, (n_channels, n_channels))
         return result
+
+    def get_weights(self, prob, classes):
+        w = prob.integer_var_matrix(keys1=[1], keys2=classes,
+                                   name="weight", lb=0, ub=self.upper_bound)
+        w = np.array([w[key] for key in w])
+        return w

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -395,6 +395,12 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
             return np.reshape(result, (n_channels, n_channels))
         return result
 
+def cvx_distance(trials, centroid, optimizer=ClassicalOptimizer()):
+    dist = [mdm(np.array([centroid]), trial, optimizer)[0] for trial in trials]
+    return dist
+
+from pyriemann.utils.distance import distance_methods
+distance_methods['convex'] = cvx_distance
 
 def mdm(X, y, optimizer=ClassicalOptimizer()):
     """Convex formulation of the MDM algorithm
@@ -445,7 +451,6 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
     wtDw = prob.sum(w[i]*w[j]*f(X[i], X[j]) for i in classes for j in classes)
 
     objectives = wtDw - _2VecLogYD
-    print(objectives)
 
     prob.set_objective("min", objectives)
 

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -433,19 +433,13 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
     prob = Model()
 
     # should be part of the optimizer
-    w = prob.continuous_var_matrix(keys1=[1], keys2=classes, name="weight", lb=-prob.infinity)
+    w = prob.continuous_var_matrix(keys1=[1], keys2=classes, name="weight", lb=0, ub=1)
     w = np.array([w[key] for key in w])
 
     _2VecLogYD = 2 * prob.sum(w[i]*f(y, X[i]) for i in classes)
 
     wtDw = prob.sum(w[i]*w[j]*f(X[i], X[j]) for i in classes for j in classes)
-    
-    # # _2VecLogYD = _2VecLogY @ D
 
-    # 
-    # w = w.reshape((n_channels, 1))
-
-    # objectives = w*D*w - _2VecLogYD
     objectives = wtDw - _2VecLogYD
     print(objectives)
 
@@ -453,4 +447,4 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
 
     result = optimizer.solve(prob, reshape=False)
 
-    return result
+    return result / sum(result)

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -430,7 +430,7 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
     n_classes, n_channels, _ = X.shape
     classes = range(n_classes)
 
-    def f(m1, m2):
+    def f(m1, m2): #distance
         return np.dot(m1.flatten(), m2.flatten())
 
     prob = Model()

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -8,6 +8,7 @@ It is for example suitable for:
 import math
 import numpy as np
 from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
+from docplex.mp.model import Model
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance
 from qiskit.algorithms import QAOA
@@ -391,6 +392,7 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
         n_channels = int(math.sqrt(result.shape[0]))
         return np.reshape(result, (n_channels, n_channels))
 
+
 def mdm(X, y, optimizer=ClassicalOptimizer()):
     """Convex formulation of the MDM algorithm
     with log-euclidian metric.
@@ -422,7 +424,7 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
         http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
 
     """
-    n_classes, n_channels, _ = covmats.shape
+    n_classes, n_channels, _ = X.shape
     channels = range(n_channels)
 
     D = [np.flatten(np.log(x)) for x in X]
@@ -442,4 +444,3 @@ def mdm(X, y, optimizer=ClassicalOptimizer()):
     result = optimizer.solve(prob)
 
     return result
-

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -360,6 +360,9 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
     ----------
     upper_bound : int (default: 7)
         The maximum integer value for matrix normalization.
+    backend: QuantumInstance (default: None)
+        A quantum backend instance.
+        If None, AerSimulator will be used.
 
     Notes
     -----
@@ -370,9 +373,10 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
     --------
     pyQiskitOptimizer
     """
-    def __init__(self, upper_bound=7):
+    def __init__(self, upper_bound=7, quantum_instance=None):
         pyQiskitOptimizer.__init__(self)
         self.upper_bound = upper_bound
+        self.quantum_instance = quantum_instance
 
     """Transform all values in the covariance matrix
     to integers.
@@ -439,8 +443,11 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
     def _solve_qp(self, qp, reshape=True):
         conv = IntegerToBinary()
         qubo = conv.convert(qp)
-        backend = get_simulator()
-        quantum_instance = QuantumInstance(backend)
+        if self.quantum_instance is None:
+            backend = get_simulator()
+            quantum_instance = QuantumInstance(backend)
+        else:
+            quantum_instance = self.quantum_instance
         qaoa_mes = QAOA(quantum_instance=quantum_instance,
                         initial_point=[0., 0.])
         qaoa = MinimumEigenOptimizer(qaoa_mes)

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -152,6 +152,7 @@ class pyQiskitOptimizer():
     Notes
     -----
     .. versionadded:: 0.0.2
+    .. versionchanged:: 0.0.4
     """
     def __init__(self):
         pass
@@ -237,6 +238,27 @@ class pyQiskitOptimizer():
         qp = from_docplex_mp(prob)
         return self._solve_qp(qp, reshape)
 
+    """Helper to create a docplex representation of a
+    weight vector.
+
+    Parameters
+    ----------
+    prob : Model
+        An instance of the docplex model [1]_
+    classes : list
+        The classes.
+
+    Returns
+    -------
+    docplex_weights : dict
+        A vector of decision variables representing
+        our weights.
+
+    Notes
+    -----
+    .. versionadded:: 0.0.4
+
+    """
     def get_weights(self, prob, classes):
         raise NotImplemented()
 
@@ -247,6 +269,7 @@ class ClassicalOptimizer(pyQiskitOptimizer):
     Notes
     -----
     .. versionadded:: 0.0.2
+    .. versionchanged:: 0.0.4
 
     See Also
     --------
@@ -300,6 +323,27 @@ class ClassicalOptimizer(pyQiskitOptimizer):
             return np.reshape(result, (n_channels, n_channels))
         return result
     
+    """Helper to create a docplex representation of a
+    weight vector.
+
+    Parameters
+    ----------
+    prob : Model
+        An instance of the docplex model [1]_
+    classes : list
+        The classes.
+
+    Returns
+    -------
+    docplex_weights : dict
+        A vector of continuous decision variables representing
+        our weights.
+
+    Notes
+    -----
+    .. versionadded:: 0.0.4
+
+    """
     def get_weights(self, prob, classes):
         w = prob.continuous_var_matrix(keys1=[1], keys2=classes,
                                    name="weight"
@@ -319,6 +363,7 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
     Notes
     -----
     .. versionadded:: 0.0.2
+    .. versionchanged:: 0.0.4
 
     See Also
     --------
@@ -404,6 +449,27 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
             return np.reshape(result, (n_channels, n_channels))
         return result
 
+    """Helper to create a docplex representation of a
+    weight vector.
+
+    Parameters
+    ----------
+    prob : Model
+        An instance of the docplex model [1]_
+    classes : list
+        The classes.
+
+    Returns
+    -------
+    docplex_weights : dict
+        A vector of integer decision variables representing
+        our weights.
+
+    Notes
+    -----
+    .. versionadded:: 0.0.4
+
+    """
     def get_weights(self, prob, classes):
         w = prob.integer_var_matrix(keys1=[1], keys2=classes,
                                    name="weight", lb=0, ub=self.upper_bound)

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -5,6 +5,7 @@ from pyriemann_qiskit.utils.docplex import ClassicalOptimizer
 
 def fro_mean_convex(covmats, sample_weight=None,
                     optimizer=ClassicalOptimizer()):
+    """comment missing"""
     n_trials, n_channels, _ = covmats.shape
     channels = range(n_channels)
     trials = range(n_trials)

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -1,6 +1,7 @@
 from docplex.mp.model import Model
 from pyriemann.utils.mean import mean_methods
-from pyriemann_qiskit.utils.docplex import ClassicalOptimizer
+from pyriemann_qiskit.utils.docplex import (ClassicalOptimizer,
+                                            get_global_optimizer)
 
 
 def fro_mean_convex(covmats, sample_weight=None,
@@ -31,6 +32,8 @@ def fro_mean_convex(covmats, sample_weight=None,
     .. [1] \
         http://ibmdecisionoptimization.github.io/docplex-doc/mp/_modules/docplex/mp/model.html#Model
     """
+
+    optimizer = get_global_optimizer(optimizer)
 
     n_trials, n_channels, _ = covmats.shape
     channels = range(n_channels)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,9 +91,15 @@ def get_dataset(rndstate):
         elif type == "bin":
             samples = _get_binary_feats(n_samples, n_features)
             labels = _get_labels(n_samples, n_classes)
-        elif type == "cov":
+        elif type == "rand_cov":
             samples = make_covariances(n_samples, n_features, 0,
                                        return_params=False)
+            labels = _get_labels(n_samples, n_classes)
+        elif type == "bin_cov":
+            samples_0 = make_covariances(n_samples // n_classes, n_features, 0,
+                                         return_params=False)
+            samples_1 = samples_0 * 2
+            samples = np.concatenate((samples_0, samples_1), axis=0)
             labels = _get_labels(n_samples, n_classes)
         else:
             samples, labels = get_mne_sample()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,17 +74,6 @@ def _get_binary_feats(n_samples, n_features):
     return samples
 
 
-def _get_binary_square_matrices(n_samples, n_features):
-    """Generate a balanced binary set of n_features-dimensional
-     samples for test purpose, containing either 0 or 1"""
-    n_classes = 2
-    class_len = n_samples // n_classes  # balanced set
-    samples_0 = np.zeros((class_len, n_features, n_features))
-    samples_1 = np.ones((class_len, n_features, n_features))
-    samples = np.concatenate((samples_0, samples_1), axis=0)
-    return samples
-
-
 @pytest.fixture
 def get_dataset(rndstate):
     """Return a dataset with shape (n_samples, n_features).
@@ -103,7 +92,8 @@ def get_dataset(rndstate):
             samples = _get_binary_feats(n_samples, n_features)
             labels = _get_labels(n_samples, n_classes)
         elif type == "cov":
-            samples = get_covmats(0)(n_samples, n_features)
+            samples = make_covariances(n_samples, n_features, 0,
+                                       return_params=False)
             labels = _get_labels(n_samples, n_classes)
         else:
             samples, labels = get_mne_sample()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,8 +102,8 @@ def get_dataset(rndstate):
         elif type == "bin":
             samples = _get_binary_feats(n_samples, n_features)
             labels = _get_labels(n_samples, n_classes)
-        elif type == "bin_square":
-            samples = _get_binary_square_matrices(n_samples, n_features)
+        elif type == "cov":
+            samples = get_covmats(0)(n_samples, n_features)
             labels = _get_labels(n_samples, n_classes)
         else:
             samples, labels = get_mne_sample()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ def _get_binary_square_matrices(n_samples, n_features):
     samples = np.concatenate((samples_0, samples_1), axis=0)
     return samples
 
+
 @pytest.fixture
 def get_dataset(rndstate):
     """Return a dataset with shape (n_samples, n_features).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,16 @@ def _get_binary_feats(n_samples, n_features):
     return samples
 
 
+def _get_binary_square_matrices(n_samples, n_features):
+    """Generate a balanced binary set of n_features-dimensional
+     samples for test purpose, containing either 0 or 1"""
+    n_classes = 2
+    class_len = n_samples // n_classes  # balanced set
+    samples_0 = np.zeros((class_len, n_features, n_features))
+    samples_1 = np.ones((class_len, n_features, n_features))
+    samples = np.concatenate((samples_0, samples_1), axis=0)
+    return samples
+
 @pytest.fixture
 def get_dataset(rndstate):
     """Return a dataset with shape (n_samples, n_features).
@@ -90,6 +100,9 @@ def get_dataset(rndstate):
             labels = _get_labels(n_samples, n_classes)
         elif type == "bin":
             samples = _get_binary_feats(n_samples, n_features)
+            labels = _get_labels(n_samples, n_classes)
+        elif type == "bin_square":
+            samples = _get_binary_square_matrices(n_samples, n_features)
             labels = _get_labels(n_samples, n_classes)
         else:
             samples, labels = get_mne_sample()

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -138,7 +138,7 @@ class TestClassicalSVM(BinaryFVT):
                self.quantum_instance.classes_[1]
 
 
-class TetQuanticSVM(TestClassicalSVM):
+class TestQuanticSVM(TestClassicalSVM):
     """Perform SVC on a simulated quantum computer.
     This test can also be run on a real computer by providing a qAccountToken
     To do so, you need to use your own token, by registering on:
@@ -155,7 +155,7 @@ class TetQuanticSVM(TestClassicalSVM):
         }
 
 
-class TetQuanticPegasosSVM(TestClassicalSVM):
+class TestQuanticPegasosSVM(TestClassicalSVM):
     """Same as TestQuanticSVM, expect it uses
     PegasosQSVC instead of QSVC implementation.
     """
@@ -170,7 +170,7 @@ class TetQuanticPegasosSVM(TestClassicalSVM):
         }
 
 
-class TetQuanticVQC(BinaryFVT):
+class TestQuanticVQC(BinaryFVT):
     """Perform VQC on a simulated quantum computer"""
     def get_params(self):
         quantum_instance = QuanticVQC(verbose=False)
@@ -209,3 +209,21 @@ class TestClassicalMDM(BinaryFVT):
                self.quantum_instance.classes_[0]
         assert self.prediction[self.class_len:].all() == \
                self.quantum_instance.classes_[1]
+
+
+class TestQuantumClassifierWithDefaultRiemannianPipeline(BinaryFVT):
+    """Functional testing for riemann quantum classifier."""
+    def get_params(self):
+        quantum_instance = \
+            QuantumClassifierWithDefaultRiemannianPipeline(
+                params={"verbose": False}
+            )
+        return {
+            "n_samples": 4,
+            "n_features": 4,
+            "quantum_instance": quantum_instance,
+            "type": None
+        }
+
+    def check(self):
+        assert len(self.prediction) == len(self.labels)

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -121,9 +121,7 @@ class BinaryFVT(BinaryTest):
 
 
 class TestClassicalSVM(BinaryFVT):
-    """ Perform standard SVC test
-    (canary test to assess pipeline correctness)
-    """
+    """ Perform functional validation testing of Quantic SVM"""
     def get_params(self):
         quantum_instance = QuanticSVM(quantum=False, verbose=False)
         return {
@@ -191,36 +189,23 @@ class TestQuanticVQC(BinaryFVT):
         assert len(self.prediction) == len(self.labels)
 
 
-class TestQuanticMDM(TestClassicalSVM):
-    """Runs MDM on a simulated quantum computer.
-    This test can also be run on a real computer by providing a qAccountToken
-    To do so, you need to use your own token, by registering on:
+class TestClassicalMDM(BinaryFVT):
+    """Test the classical version of MDM is used
+    when quantum is false
     https://quantum-computing.ibm.com/
     Note that the "real quantum version" of this test may also take some time.
     """
     def get_params(self):
-        quantum_instance = QuanticMDM(quantum=True, verbose=False)
+        quantum_instance = QuanticMDM(quantum=False, verbose=False)
         return {
-            "n_samples": 10,
-            "n_features": 4,
+            "n_samples": 100,
+            "n_features": 9,
             "quantum_instance": quantum_instance,
             "type": "bin"
         }
 
-
-class TestQuantumClassifierWithDefaultRiemannianPipeline(BinaryFVT):
-    """Functional testing for riemann quantum classifier."""
-    def get_params(self):
-        quantum_instance = \
-            QuantumClassifierWithDefaultRiemannianPipeline(
-                params={"verbose": False}
-            )
-        return {
-            "n_samples": 4,
-            "n_features": 4,
-            "quantum_instance": quantum_instance,
-            "type": None
-        }
-
     def check(self):
-        assert len(self.prediction) == len(self.labels)
+        assert self.prediction[:self.class_len].all() == \
+               self.quantum_instance.classes_[0]
+        assert self.prediction[self.class_len:].all() == \
+               self.quantum_instance.classes_[1]

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -201,7 +201,7 @@ class TestClassicalMDM(BinaryFVT):
             "n_samples": 100,
             "n_features": 9,
             "quantum_instance": quantum_instance,
-            "type": "cov"
+            "type": "bin_cov"
         }
 
     def check(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -201,7 +201,7 @@ class TestClassicalMDM(BinaryFVT):
             "n_samples": 100,
             "n_features": 9,
             "quantum_instance": quantum_instance,
-            "type": "mne"
+            "type": "bin_square"
         }
 
     def check(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -5,6 +5,7 @@ from pyriemann.estimation import XdawnCovariances
 from pyriemann_qiskit.classification \
     import (QuanticSVM,
             QuanticVQC,
+            QuanticMDM,
             QuantumClassifierWithDefaultRiemannianPipeline)
 from pyriemann_qiskit.datasets import get_mne_sample
 from pyriemann_qiskit.utils.filtering import NaiveDimRed
@@ -17,6 +18,8 @@ from operator import itemgetter
                          [make_pipeline(XdawnCovariances(nfilter=1),
                                         TangentSpace(), NaiveDimRed(),
                                         QuanticSVM(quantum=False)),
+                          make_pipeline(XdawnCovariances(nfilter=1),
+                                        QuanticMDM(quantum=False)),
                           QuantumClassifierWithDefaultRiemannianPipeline(
                               nfilter=1,
                               shots=None)])
@@ -186,6 +189,23 @@ class TestQuanticVQC(BinaryFVT):
         # Considering the inputs, this probably make no sense to test accuracy.
         # Instead, we could consider this test as a canary test
         assert len(self.prediction) == len(self.labels)
+
+
+class TestQuanticMDM(TestClassicalSVM):
+    """Runs MDM on a simulated quantum computer.
+    This test can also be run on a real computer by providing a qAccountToken
+    To do so, you need to use your own token, by registering on:
+    https://quantum-computing.ibm.com/
+    Note that the "real quantum version" of this test may also take some time.
+    """
+    def get_params(self):
+        quantum_instance = QuanticMDM(quantum=True, verbose=False)
+        return {
+            "n_samples": 10,
+            "n_features": 4,
+            "quantum_instance": quantum_instance,
+            "type": "bin"
+        }
 
 
 class TestQuantumClassifierWithDefaultRiemannianPipeline(BinaryFVT):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -201,7 +201,7 @@ class TestClassicalMDM(BinaryFVT):
             "n_samples": 100,
             "n_features": 9,
             "quantum_instance": quantum_instance,
-            "type": "bin"
+            "type": "mne"
         }
 
     def check(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -201,7 +201,7 @@ class TestClassicalMDM(BinaryFVT):
             "n_samples": 100,
             "n_features": 9,
             "quantum_instance": quantum_instance,
-            "type": "bin_square"
+            "type": "cov"
         }
 
     def check(self):

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -138,7 +138,7 @@ class TestClassicalSVM(BinaryFVT):
                self.quantum_instance.classes_[1]
 
 
-class TestQuanticSVM(TestClassicalSVM):
+class TetQuanticSVM(TestClassicalSVM):
     """Perform SVC on a simulated quantum computer.
     This test can also be run on a real computer by providing a qAccountToken
     To do so, you need to use your own token, by registering on:
@@ -155,7 +155,7 @@ class TestQuanticSVM(TestClassicalSVM):
         }
 
 
-class TestQuanticPegasosSVM(TestClassicalSVM):
+class TetQuanticPegasosSVM(TestClassicalSVM):
     """Same as TestQuanticSVM, expect it uses
     PegasosQSVC instead of QSVC implementation.
     """
@@ -170,7 +170,7 @@ class TestQuanticPegasosSVM(TestClassicalSVM):
         }
 
 
-class TestQuanticVQC(BinaryFVT):
+class TetQuanticVQC(BinaryFVT):
     """Perform VQC on a simulated quantum computer"""
     def get_params(self):
         quantum_instance = QuanticVQC(verbose=False)

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -47,4 +47,4 @@ def test_mdm():
     X = np.stack((X_0, X_1))
     y = np.full((2, 2), 0.3)
     weight = mdm(X, y)
-    assert weight is None
+    assert sum(weight) == 1

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from docplex.mp.model import Model
 from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
 from pyriemann_qiskit.utils import (square_cont_mat_var,

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -44,6 +44,7 @@ def test_optimizer_creation(optimizer):
 def test_mdm():
     X_0 = np.zeros((2, 2))
     X_1 = np.ones((2, 2))
+    X = np.array([X_0, X_1])
     y = np.full((2, 2), 0.3)
-    weight = mdm([X_0, X_1], y)
+    weight = mdm(X, y)
     assert weight is None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -6,8 +6,7 @@ from pyriemann_qiskit.utils import (square_cont_mat_var,
                                     square_int_mat_var,
                                     square_bin_mat_var,
                                     ClassicalOptimizer,
-                                    NaiveQAOAOptimizer,
-                                    logeucl_dist_convex)
+                                    NaiveQAOAOptimizer)
 
 
 @pytest.mark.parametrize('square_mat_var',
@@ -39,12 +38,3 @@ def test_get_square_cont_var(square_mat_var):
                           NaiveQAOAOptimizer])
 def test_optimizer_creation(optimizer):
     assert optimizer()
-
-
-def test_logeucl_dist_convex():
-    X_0 = np.ones((2, 2))
-    X_1 = X_0 + 1
-    X = np.stack((X_0, X_1))
-    y = np.full((2, 2), 0.3)
-    weight = logeucl_dist_convex(X, y)
-    assert sum(weight) == 1

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -42,8 +42,8 @@ def test_optimizer_creation(optimizer):
 
 
 def test_mdm():
-    X_0 = np.zeros((2,2))
-    X_1 = np.ones((2,2))
-    y = np.full((2,2), 0.3)
-    weight = mdm([X0, X1], y)
+    X_0 = np.zeros((2, 2))
+    X_1 = np.ones((2, 2))
+    y = np.full((2, 2), 0.3)
+    weight = mdm([X_0, X_1], y)
     assert weight is None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -1,11 +1,13 @@
 import pytest
+import numpy as np
 from docplex.mp.model import Model
 from docplex.mp.vartype import ContinuousVarType, IntegerVarType, BinaryVarType
 from pyriemann_qiskit.utils import (square_cont_mat_var,
                                     square_int_mat_var,
                                     square_bin_mat_var,
                                     ClassicalOptimizer,
-                                    NaiveQAOAOptimizer)
+                                    NaiveQAOAOptimizer,
+                                    mdm)
 
 
 @pytest.mark.parametrize('square_mat_var',
@@ -37,3 +39,11 @@ def test_get_square_cont_var(square_mat_var):
                           NaiveQAOAOptimizer])
 def test_optimizer_creation(optimizer):
     assert optimizer()
+
+
+def test_mdm():
+    X_0 = np.zeros((2,2))
+    X_1 = np.ones((2,2))
+    y = np.full((2,2), 0.3)
+    weight = mdm([X0, X1], y)
+    assert weight is None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -42,8 +42,8 @@ def test_optimizer_creation(optimizer):
 
 
 def test_mdm():
-    X_0 = np.zeros((2, 2))
-    X_1 = np.ones((2, 2))
+    X_0 = np.ones((2, 2))
+    X_1 = X_0 + 1
     X = np.stack((X_0, X_1))
     y = np.full((2, 2), 0.3)
     weight = mdm(X, y)

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -44,7 +44,7 @@ def test_optimizer_creation(optimizer):
 def test_mdm():
     X_0 = np.zeros((2, 2))
     X_1 = np.ones((2, 2))
-    X = np.array([X_0, X_1])
+    X = np.ndarray([X_0, X_1])
     y = np.full((2, 2), 0.3)
     weight = mdm(X, y)
     assert weight is None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -7,7 +7,7 @@ from pyriemann_qiskit.utils import (square_cont_mat_var,
                                     square_bin_mat_var,
                                     ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
-                                    mdm)
+                                    logeucl_dist_convex)
 
 
 @pytest.mark.parametrize('square_mat_var',
@@ -41,10 +41,10 @@ def test_optimizer_creation(optimizer):
     assert optimizer()
 
 
-def test_mdm():
+def test_logeucl_dist_convex():
     X_0 = np.ones((2, 2))
     X_1 = X_0 + 1
     X = np.stack((X_0, X_1))
     y = np.full((2, 2), 0.3)
-    weight = mdm(X, y)
+    weight = logeucl_dist_convex(X, y)
     assert sum(weight) == 1

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -44,7 +44,7 @@ def test_optimizer_creation(optimizer):
 def test_mdm():
     X_0 = np.zeros((2, 2))
     X_1 = np.ones((2, 2))
-    X = np.concatenate((X_0, X_1), axis=0)
+    X = np.stack((X_0, X_1))
     y = np.full((2, 2), 0.3)
     weight = mdm(X, y)
     assert weight is None

--- a/tests/test_docplex.py
+++ b/tests/test_docplex.py
@@ -44,7 +44,7 @@ def test_optimizer_creation(optimizer):
 def test_mdm():
     X_0 = np.zeros((2, 2))
     X_1 = np.ones((2, 2))
-    X = np.ndarray([X_0, X_1])
+    X = np.concatenate((X_0, X_1), axis=0)
     y = np.full((2, 2), 0.3)
     weight = mdm(X, y)
     assert weight is None

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -11,7 +11,7 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 def test_performance(get_covmats, get_labels):
     metric = {
-        'mean': "logeuclid",
+        'mean': "euclid",
         'distance': "convex"
     }
 

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -17,7 +17,7 @@ def test_performance():
     }
 
     clf = make_pipeline(XdawnCovariances(), MDM(metric=metric))
-    skf = StratifiedKFold(n_splits=5)
+    skf = StratifiedKFold(n_splits=3)
     covset, labels = get_mne_sample()
     score = cross_val_score(clf, covset, labels, cv=skf, scoring='roc_auc')
     assert score.mean() > 0

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -1,0 +1,33 @@
+import pytest
+import numpy as np
+from pyriemann_qiskit.utils import (ClassicalOptimizer,
+                                    NaiveQAOAOptimizer,
+                                    logeucl_dist_convex)
+
+
+def test_performance(get_covmats, get_labels):
+    metric = {
+        'mean': "logeuclid",
+        'distance': "convex"
+    }
+
+    clf = make_pipeline(XdawnCovariances(), MDM(metric=metric))
+    skf = StratifiedKFold(n_splits=5)
+    n_matrices, n_channels, n_classes = 100, 3, 2
+    covset = get_covmats(n_matrices, n_channels)
+    labels = get_labels(n_matrices, n_classes)
+
+    score = cross_val_score(clf, covset, labels, cv=skf, scoring='roc_auc')
+    assert score.mean() > 0
+
+
+@pytest.mark.parametrize('optimizer',
+                         [ClassicalOptimizer(),
+                          NaiveQAOAOptimizer()])
+def test_logeucl_dist_convex(optimizer):
+    X_0 = np.ones((2, 2))
+    X_1 = X_0 + 1
+    X = np.stack((X_0, X_1))
+    y = np.full((2, 2), 0.3)
+    weight = logeucl_dist_convex(X, y, optimizer=optimizer)
+    assert weight.argmax == 0 # 0.3 closer to 1

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -12,7 +12,7 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 def test_performance():
     metric = {
-        'mean': "euclid",
+        'mean': "logeuclid",
         'distance': "convex"
     }
 

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -3,13 +3,11 @@ import numpy as np
 from pyriemann_qiskit.utils import (ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
                                     logeucl_dist_convex)
-
-from pyriemann.utils.mean import mean_euclid
-from pyriemann.utils.distance import distance_methods
 from pyriemann.classification import MDM
 from pyriemann.estimation import XdawnCovariances
 from sklearn.pipeline import make_pipeline
 from sklearn.model_selection import StratifiedKFold, cross_val_score
+
 
 def test_performance(get_covmats, get_labels):
     metric = {

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -3,7 +3,12 @@ import numpy as np
 from pyriemann_qiskit.utils import (ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
                                     logeucl_dist_convex)
-
+from pyriemann.utils.mean import mean_euclid
+from pyriemann.utils.distance import distance_methods
+from pyriemann.classification import MDM
+from pyriemann.estimation import XdawnCovariances
+from sklearn.pipeline import make_pipeline
+from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 def test_performance(get_covmats, get_labels):
     metric = {
@@ -25,9 +30,9 @@ def test_performance(get_covmats, get_labels):
                          [ClassicalOptimizer(),
                           NaiveQAOAOptimizer()])
 def test_logeucl_dist_convex(optimizer):
-    X_0 = np.ones((2, 2))
+    X_0 = np.array([[0.9, 1.1],[0.9, 1.1]])
     X_1 = X_0 + 1
     X = np.stack((X_0, X_1))
-    y = np.full((2, 2), 0.3)
+    y = (X_0 + X_1) / 3
     weight = logeucl_dist_convex(X, y, optimizer=optimizer)
-    assert weight.argmax == 0 # 0.3 closer to 1
+    assert weight.argmin() == 0 # 0.3 closer to 1

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -3,13 +3,14 @@ import numpy as np
 from pyriemann_qiskit.utils import (ClassicalOptimizer,
                                     NaiveQAOAOptimizer,
                                     logeucl_dist_convex)
+from pyriemann_qiskit.datasets import get_mne_sample
 from pyriemann.classification import MDM
 from pyriemann.estimation import XdawnCovariances
 from sklearn.pipeline import make_pipeline
 from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 
-def test_performance(get_covmats, get_labels):
+def test_performance():
     metric = {
         'mean': "euclid",
         'distance': "convex"
@@ -17,10 +18,7 @@ def test_performance(get_covmats, get_labels):
 
     clf = make_pipeline(XdawnCovariances(), MDM(metric=metric))
     skf = StratifiedKFold(n_splits=5)
-    n_matrices, n_channels, n_classes = 100, 3, 2
-    covset = get_covmats(n_matrices, n_channels)
-    labels = get_labels(n_matrices, n_classes)
-
+    covset, labels = get_mne_sample()
     score = cross_val_score(clf, covset, labels, cv=skf, scoring='roc_auc')
     assert score.mean() > 0
 

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -14,10 +14,8 @@ from pyriemann_qiskit.utils import (ClassicalOptimizer,
 def test_performance(get_covmats, get_labels):
     metric = {
         'mean': "convex",
-        'distance': "convex"
+        'distance': "logeuclid"
     }
-
-    distance_methods["convex"] = lambda A, B: np.linalg.norm(A - B, ord='fro')
 
     clf = make_pipeline(XdawnCovariances(), MDM(metric=metric))
     skf = StratifiedKFold(n_splits=5)

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -13,7 +13,7 @@ from pyriemann_qiskit.utils import (ClassicalOptimizer,
 def test_performance(get_covmats, get_labels):
     metric = {
         'mean': "convex",
-        'distance': "logeuclid"
+        'distance': "euclid"
     }
 
     clf = make_pipeline(XdawnCovariances(), MDM(metric=metric))

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 from pyriemann.utils.mean import mean_euclid
-from pyriemann.utils.distance import distance_methods
 from pyriemann.classification import MDM
 from pyriemann.estimation import XdawnCovariances
 from sklearn.pipeline import make_pipeline


### PR DESCRIPTION
This PR is part of #27.
It overrides `MDM._predict_distances` to be compatible with our convex distance. 
It also provides a wrapper around MDM which inherits from `QuanticClassifierBase`.
This allows running the optimization on a quantum backend if the convex metric is selected and `quantum=True`.
@toncho FYI
