### PR TITLE
correct doc for fro_mean_convex

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ variational quantum classifier’, J. High Energ. Phys., vol. 2021, no. 2, p. 21
 Classification’, Phys. Rev. Lett., vol. 113, no. 13, p. 130503, Sep. 2014,
 https://doi.org/10.1103/PhysRevLett.113.130503
 
-[3] H. Abraham et al., Qiskit: An Open-source Framework for Quantum Computing.
-Zenodo, 2019, https://doi.org/10.5281/zenodo.2562110.
+[3] H. Abraham et al., Qiskit: An Open-source Framework for Quantum Computing. Zenodo,
+2019, https://doi.org/10.5281/zenodo.2562110.
 
 [4] V. Havlíček et al., ‘Supervised learning with quantum-enhanced feature spaces’,
 Nature, vol. 567, no. 7747, pp. 209–212, Mar. 2019,
@@ -74,8 +74,7 @@ https://doi.org/10.1038/s41586-019-0980-2
 
 [5] G. Cattan, A. Andreev, First steps to the classification of ERPs using quantum
 computation, NTB Berlin 2022 - International Forum on Neural Engineering & Brain
-Technologies, May 2022, Berlin, Germany,
-https://hal.archives-ouvertes.fr/hal-03672246/
+Technologies, May 2022, Berlin, Germany, https://hal.archives-ouvertes.fr/hal-03672246/
 
 ### How to cite?
 

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -7,11 +7,11 @@ from pyriemann.estimation import Shrinkage
 def fro_mean_convex(
     covmats, sample_weight=None, optimizer=ClassicalOptimizer(), shrink=True
 ):
-    """Convex formulation of the mean
-    with frobenius distance.
+    """Convex formulation of the mean with Frobenius distance.
+
     Parameters
     ----------
-    covmats: ndarray, shape (n_classes, n_channels, n_channels)
+    covmats: ndarray, shape (n_matrices, n_channels, n_channels)
         Set of SPD matrices.
     sample_weights:  None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix. Never used in practice.
@@ -25,7 +25,7 @@ def fro_mean_convex(
     Returns
     -------
     mean : ndarray, shape (n_channels, n_channels)
-        Convex-optimized forbenius mean.
+        Convex-optimized Frobenius mean.
 
     Notes
     -----


### PR DESCRIPTION
Current doc display is broken for `fro_mean_convex`

See https://pyriemann-qiskit.readthedocs.io/en/latest/api.html#mean
and https://pyriemann-qiskit.readthedocs.io/en/latest/generated/pyriemann_qiskit.utils.mean.fro_mean_convex.html