### PR TITLE
Feat/mdm predict distances

### DIFF
--- a/benchmarks/light_benchmark.py
+++ b/benchmarks/light_benchmark.py
@@ -88,7 +88,7 @@ pipelines["QMDM_mean"] = QuantumMDMWithRiemannianPipeline(
 )
 
 pipelines["QMDM_dist"] = QuantumMDMWithRiemannianPipeline(
-    metric={"mean": "logeuclid", "distance": "logeuclid_cpm"}, quantum=True
+    metric={"mean": "logeuclid", "distance": "logeuclid_hull_cpm"}, quantum=True
 )
 
 pipelines["RG_LDA"] = make_pipeline(

--- a/benchmarks/light_benchmark.py
+++ b/benchmarks/light_benchmark.py
@@ -82,13 +82,13 @@ pipelines["RG_VQC"] = QuantumClassifierWithDefaultRiemannianPipeline(
 )
 
 pipelines["QMDM_mean"] = QuantumMDMWithRiemannianPipeline(
-    metric={"mean": "euclid_cpm", "distance": "euclid"},
+    metric={"mean": "qeuclid", "distance": "euclid"},
     quantum=True,
     regularization=Shrinkage(shrinkage=0.9),
 )
 
 pipelines["QMDM_dist"] = QuantumMDMWithRiemannianPipeline(
-    metric={"mean": "logeuclid", "distance": "logeuclid_hull_cpm"}, quantum=True
+    metric={"mean": "logeuclid", "distance": "qlogeuclid_hull"}, quantum=True
 )
 
 pipelines["RG_LDA"] = make_pipeline(

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -96,8 +96,8 @@ Mean
 .. autosummary::
     :toctree: generated/
 
-    mean_euclid_cpm
-    mean_logeuclid_cpm
+    qmean_euclid
+    qmean_logeuclid
 
 Distance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -107,7 +107,8 @@ Distance
 .. autosummary::
     :toctree: generated/
 
-    distance_logeuclid_cpm
+    qdistance_logeuclid_to_convex_hull
+    weights_logeuclid_to_convex_hull
 
 Docplex
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -49,7 +49,17 @@ Ensemble
 Utils function
 --------------
 
-Utils functions are low level functions for the `classification` module.
+Utils functions are low level functions for the `classification` and `pipelines` module.
+
+Utils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _hyper_params_factory_api:
+.. currentmodule:: pyriemann_qiskit.utils.utils
+
+.. autosummary::
+    :toctree: generated/
+
+    is_qfunction
 
 Hyper-parameters generation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/ERP/classify_P300_bi_quantum_mdm.py
+++ b/examples/ERP/classify_P300_bi_quantum_mdm.py
@@ -107,15 +107,15 @@ labels_dict = {"Target": 1, "NonTarget": 0}
 
 pipelines = {}
 
-pipelines["mean=logeuclid_cpm/distance=logeuclid"] = QuantumMDMWithRiemannianPipeline(
+pipelines["mean=qlogeuclid/distance=logeuclid"] = QuantumMDMWithRiemannianPipeline(
     metric="mean", quantum=quantum
 )
 
-pipelines["mean=logeuclid/distance=logeuclid_cpm"] = QuantumMDMWithRiemannianPipeline(
+pipelines["mean=logeuclid/distance=qlogeuclid"] = QuantumMDMWithRiemannianPipeline(
     metric="distance", quantum=quantum
 )
 
-pipelines["Voting logeuclid_cpm"] = QuantumMDMVotingClassifier(quantum=quantum)
+pipelines["Voting qlogeuclid"] = QuantumMDMVotingClassifier(quantum=quantum)
 
 ##############################################################################
 # Run evaluation

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -588,8 +588,8 @@ class QuanticVQC(QuanticClassifierBase):
 def predict_distances(mdm):
     def _predict_distances(X):
         if is_qdist(mdm.metric_dist):
-            if "qlogeuclid_hull" in mdm.metric_dist:
-                warn("qlogeuclid_hull should not be use inside MDM")
+            if "hull" in mdm.metric_dist:
+                warn("qdistances to hull should not be use inside MDM")
             else:
                 warn(
                     "q-distances for MDM are toy functions.\

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -586,8 +586,8 @@ class QuanticMDM(QuanticClassifierBase):
 
     """Quantum-enhanced MDM classifier
 
-    This class is a quantic implementation of the Minimum Distance to Mean (MDM)
-    [1]_, which can run with quantum optimization.
+    This class is a quantic implementation of the Minimum Distance to Mean
+    (MDM) [1]_, which can run with quantum optimization.
     Only log-Euclidean distance between trial and class prototypes is supported
     at the moment, but any type of metric can be used for centroid estimation.
 
@@ -603,37 +603,36 @@ class QuanticMDM(QuanticClassifierBase):
 
     Parameters
     ----------
-    metric : string | dict, default={"mean": 'logeuclid', "distance": 'cpm'}
+    metric : string | dict, default={"mean": 'logeuclid', \
+            "distance": 'qlogeuclid_hull'}
         The type of metric used for centroid and distance estimation.
         see `mean_covariance` for the list of supported metric.
         the metric could be a dict with two keys, `mean` and `distance` in
         order to pass different metrics for the centroid estimation and the
-        distance estimation. Typical usecase is to pass 'logeuclid' metric for
-        the mean in order to boost the computional speed and 'riemann' for the
-        distance in order to keep the good sensitivity for the classification.
-    quantum : bool (default: True)
-        Only applies if `metric` contains a cpm distance or mean.
+        distance estimation.
+    quantum : bool, default=True
+        Only applies if `metric` contains a quantic distance or mean.
 
         - If true will run on local or remote backend
           (depending on q_account_token value),
         - If false, will perform classical computing instead.
-    q_account_token : string (default:None)
+    q_account_token : string, default=None
         If `quantum` is True and `q_account_token` provided,
         the classification task will be running on a IBM quantum backend.
         If `load_account` is provided, the classifier will use the previous
         token saved with `IBMProvider.save_account()`.
-    verbose : bool (default:True)
+    verbose : bool, default=True
         If true, will output all intermediate results and logs.
-    shots : int (default:1024)
+    shots : int, default=1024
         Number of repetitions of each circuit, for sampling.
-    seed: int | None (default: None)
+    seed : int | None, default=None
         Random seed for the simulation
-    upper_bound : int (default: 7)
+    upper_bound : int, default=7
         The maximum integer value for matrix normalization.
-    regularization: MixinTransformer (defulat: None)
+    regularization : MixinTransformer, default=None
         Additional post-processing to regularize means.
-    classical_optimizer : OptimizationAlgorithm
-        An instance of OptimizationAlgorithm [3]_
+    classical_optimizer : OptimizationAlgorithm, default=CobylaOptimizer()
+        An instance of OptimizationAlgorithm [3]_.
 
     See Also
     --------
@@ -676,12 +675,15 @@ class QuanticMDM(QuanticClassifierBase):
         self.regularization = regularization
         self.classical_optimizer = classical_optimizer
 
-    # We override the _predict_distances method
-    # inside MDM to allow the use of qdistance.
-    # This is due to the fact the the signature of qdistances is different from
-    # the usual distance functions.
     @staticmethod
     def _override_predict_distance(mdm):
+        """Override _predict_distances method of MDM.
+
+        We override the _predict_distances method inside MDM to allow the use
+        of qdistance.
+        This is due to the fact the the signature of qdistances is different
+        from the usual distance functions.
+        """
         def _predict_distances(X):
             if is_qfunction(mdm.metric_dist):
                 if "hull" in mdm.metric_dist:

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from scipy.special import softmax
 import logging
 import numpy as np
+from warnings import warn
 
 from pyriemann.classification import MDM
 from pyriemann_qiskit.datasets import get_feature_dimension
@@ -587,6 +588,11 @@ class QuanticVQC(QuanticClassifierBase):
 def predict_distances(mdm):
     def _predict_distances(X):
             if is_cpm_dist(mdm.metric_dist):
+                if "logeuclid_hull_cpm" in mdm.metric_dist:
+                    warn("logeuclid_hull_cpm should not be use inside MDM")
+                else:
+                    warn("CPM distances for MDM are toy functions.\
+                        Use pyRiemann distances instead.")
                 distance = distance_functions[mdm.metric_dist]
                 centroids = np.array(mdm.covmeans_)
                 weights = [

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -16,7 +16,7 @@ from pyriemann_qiskit.utils import (
     NaiveQAOAOptimizer,
     set_global_optimizer,
 )
-from pyriemann_qiskit.utils.distance import distance_logeuclid_to_convex_hull_cpm, distance_functions
+from pyriemann_qiskit.utils.distance import distance_functions, is_cpm_dist
 from qiskit.utils import QuantumInstance
 from qiskit.utils.quantum_instance import logger
 from qiskit_ibm_provider import IBMProvider, least_busy
@@ -586,7 +586,7 @@ class QuanticVQC(QuanticClassifierBase):
 # the usual distance functions.
 def predict_distances(mdm):
     def _predict_distances(X):
-            if "_cpm" in mdm.metric_dist:
+            if is_cpm_dist(mdm.metric_dist):
                 distance = distance_functions[mdm.metric_dist]
                 centroids = np.array(mdm.covmeans_)
                 weights = [

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -16,7 +16,7 @@ from pyriemann_qiskit.utils import (
     NaiveQAOAOptimizer,
     set_global_optimizer,
 )
-from pyriemann_qiskit.utils.distance import distance_logeuclid_cpm
+from pyriemann_qiskit.utils.distance import distance_logeuclid_to_convex_hull_cpm
 from qiskit.utils import QuantumInstance
 from qiskit.utils.quantum_instance import logger
 from qiskit_ibm_provider import IBMProvider, least_busy
@@ -582,15 +582,15 @@ class QuanticVQC(QuanticClassifierBase):
 
 # This is only for validation inside the MDM.
 # In fact, we override the _predict_distances method
-# inside MDM to directly use distance_logeuclid_cpm when the metric is "logeuclid_cpm"
+# inside MDM to directly use distance_logeuclid_cpm when the metric is "logeuclid_hull_cpm"
 # This is due to the fact the the signature of this method is different from
 # the usual distance functions.
 def predict_distances(mdm):
     def _predict_distances(X):
-            if mdm.metric_dist == "logeuclid_cpm":
+            if mdm.metric_dist == "logeuclid_hull_cpm":
                 centroids = np.array(mdm.covmeans_)
                 weights = [
-                    distance_logeuclid_cpm(centroids, x, return_weights=True)[1] for x in X
+                    distance_logeuclid_to_convex_hull_cpm(centroids, x, return_weights=True)[1] for x in X
                 ]
                 return 1 - np.array(weights)
             else:
@@ -673,7 +673,7 @@ class QuanticMDM(QuanticClassifierBase):
 
     def __init__(
         self,
-        metric={"mean": "logeuclid", "distance": "logeuclid_cpm"},
+        metric={"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
         quantum=True,
         q_account_token=None,
         verbose=True,

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -17,7 +17,8 @@ from pyriemann_qiskit.utils import (
     NaiveQAOAOptimizer,
     set_global_optimizer,
 )
-from pyriemann_qiskit.utils.distance import distance_functions, is_qdist
+from pyriemann_qiskit.utils.distance import distance_functions
+from pyriemann_qiskit.utils.utils import is_qfunction
 from qiskit.utils import QuantumInstance
 from qiskit.utils.quantum_instance import logger
 from qiskit_ibm_provider import IBMProvider, least_busy
@@ -682,7 +683,7 @@ class QuanticMDM(QuanticClassifierBase):
     @staticmethod
     def _override_predict_distance(mdm):
         def _predict_distances(X):
-            if is_qdist(mdm.metric_dist):
+            if is_qfunction(mdm.metric_dist):
                 if "hull" in mdm.metric_dist:
                     warn("qdistances to hull should not be use inside MDM")
                 else:

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -17,7 +17,7 @@ from pyriemann_qiskit.utils import (
     NaiveQAOAOptimizer,
     set_global_optimizer,
 )
-from pyriemann_qiskit.utils.distance import distance_functions, is_cpm_dist
+from pyriemann_qiskit.utils.distance import distance_functions, is_qdist
 from qiskit.utils import QuantumInstance
 from qiskit.utils.quantum_instance import logger
 from qiskit_ibm_provider import IBMProvider, least_busy
@@ -587,12 +587,12 @@ class QuanticVQC(QuanticClassifierBase):
 # the usual distance functions.
 def predict_distances(mdm):
     def _predict_distances(X):
-        if is_cpm_dist(mdm.metric_dist):
-            if "logeuclid_hull_cpm" in mdm.metric_dist:
-                warn("logeuclid_hull_cpm should not be use inside MDM")
+        if is_qdist(mdm.metric_dist):
+            if "qlogeuclid_hull" in mdm.metric_dist:
+                warn("qlogeuclid_hull should not be use inside MDM")
             else:
                 warn(
-                    "CPM distances for MDM are toy functions.\
+                    "q-distances for MDM are toy functions.\
                         Use pyRiemann distances instead."
                 )
             distance = distance_functions[mdm.metric_dist]
@@ -681,7 +681,7 @@ class QuanticMDM(QuanticClassifierBase):
 
     def __init__(
         self,
-        metric={"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
+        metric={"mean": "logeuclid", "distance": "qlogeuclid_hull"},
         quantum=True,
         q_account_token=None,
         verbose=True,

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -587,22 +587,24 @@ class QuanticVQC(QuanticClassifierBase):
 # the usual distance functions.
 def predict_distances(mdm):
     def _predict_distances(X):
-            if is_cpm_dist(mdm.metric_dist):
-                if "logeuclid_hull_cpm" in mdm.metric_dist:
-                    warn("logeuclid_hull_cpm should not be use inside MDM")
-                else:
-                    warn("CPM distances for MDM are toy functions.\
-                        Use pyRiemann distances instead.")
-                distance = distance_functions[mdm.metric_dist]
-                centroids = np.array(mdm.covmeans_)
-                weights = [
-                    distance(centroids, x) for x in X
-                ]
-                return 1 - np.array(weights)
+        if is_cpm_dist(mdm.metric_dist):
+            if "logeuclid_hull_cpm" in mdm.metric_dist:
+                warn("logeuclid_hull_cpm should not be use inside MDM")
             else:
-                return MDM._predict_distances(mdm, X)
+                warn(
+                    "CPM distances for MDM are toy functions.\
+                        Use pyRiemann distances instead."
+                )
+            distance = distance_functions[mdm.metric_dist]
+            centroids = np.array(mdm.covmeans_)
+            weights = [distance(centroids, x) for x in X]
+            return 1 - np.array(weights)
+        else:
+            return MDM._predict_distances(mdm, X)
+
     return _predict_distances
-        
+
+
 class QuanticMDM(QuanticClassifierBase):
 
     """Quantum-enhanced MDM classifier
@@ -696,7 +698,7 @@ class QuanticMDM(QuanticClassifierBase):
         self.upper_bound = upper_bound
         self.regularization = regularization
         self.classical_optimizer = classical_optimizer
-    
+
     def _init_algo(self, n_features):
         self._log("Quantic MDM initiating algorithm")
         classifier = MDM(metric=self.metric)

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -702,7 +702,9 @@ class QuanticMDM(QuanticClassifierBase):
     def _init_algo(self, n_features):
         self._log("Quantic MDM initiating algorithm")
         classifier = MDM(metric=self.metric)
-        classifier._predict_distances = QuanticMDM._override_predict_distance(classifier)
+        classifier._predict_distances = QuanticMDM._override_predict_distance(
+            classifier
+        )
         if self.quantum:
             self._log("Using NaiveQAOAOptimizer")
             self._optimizer = NaiveQAOAOptimizer(

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -684,6 +684,7 @@ class QuanticMDM(QuanticClassifierBase):
         This is due to the fact the the signature of qdistances is different
         from the usual distance functions.
         """
+
         def _predict_distances(X):
             if is_qfunction(mdm.metric_dist):
                 if "hull" in mdm.metric_dist:

--- a/pyriemann_qiskit/pipelines.py
+++ b/pyriemann_qiskit/pipelines.py
@@ -8,7 +8,7 @@ from qiskit_optimization.algorithms import CobylaOptimizer
 from pyriemann.estimation import XdawnCovariances, ERPCovariances
 from pyriemann.tangentspace import TangentSpace
 from pyriemann.preprocessing import Whitening
-from pyriemann_qiskit.utils.mean import is_cpm_mean
+from pyriemann_qiskit.utils.mean import is_qmean
 from pyriemann_qiskit.utils.filtering import NoDimRed
 from pyriemann_qiskit.utils.hyper_params_factory import (
     # gen_zz_feature_map,
@@ -312,7 +312,7 @@ class QuantumMDMWithRiemannianPipeline(BasePipeline):
 
     Parameters
     ----------
-    metric : string | dict, default={"mean": 'logeuclid', "distance": 'logeuclid_cpm'}
+    metric : string | dict, default={"mean": 'logeuclid', "distance": 'qlogeuclid'}
         The type of metric used for centroid and distance estimation.
     quantum : bool (default: True)
         - If true will run on local or remote backend
@@ -361,7 +361,7 @@ class QuantumMDMWithRiemannianPipeline(BasePipeline):
 
     def __init__(
         self,
-        metric={"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
+        metric={"mean": "logeuclid", "distance": "qlogeuclid_hull"},
         quantum=True,
         q_account_token=None,
         verbose=True,
@@ -384,7 +384,7 @@ class QuantumMDMWithRiemannianPipeline(BasePipeline):
     def _create_pipe(self):
         print(self.metric)
         print(self.metric["mean"])
-        if is_cpm_mean(self.metric["mean"]):
+        if is_qmean(self.metric["mean"]):
             if self.quantum:
                 covariances = XdawnCovariances(
                     nfilter=1, estimator="scm", xdawn_estimator="lwf"
@@ -418,8 +418,8 @@ class QuantumMDMVotingClassifier(BasePipeline):
     Voting classifier with two configurations of
     QuantumMDMWithRiemannianPipeline:
 
-    - with mean = euclid_cpm and distance = euclid,
-    - with mean = logeuclid and distance = logeuclid_cpm.
+    - with mean = qeuclid and distance = euclid,
+    - with mean = logeuclid and distance = qlogeuclid.
 
     Parameters
     ----------
@@ -472,7 +472,7 @@ class QuantumMDMVotingClassifier(BasePipeline):
 
     def _create_pipe(self):
         clf_mean_logeuclid_dist_cpm = QuantumMDMWithRiemannianPipeline(
-            {"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
+            {"mean": "logeuclid", "distance": "qlogeuclid_hull"},
             self.quantum,
             self.q_account_token,
             self.verbose,
@@ -480,7 +480,7 @@ class QuantumMDMVotingClassifier(BasePipeline):
             self.upper_bound,
         )
         clf_mean_cpm_dist_euclid = QuantumMDMWithRiemannianPipeline(
-            {"mean": "euclid_cpm", "distance": "euclid"},
+            {"mean": "qeuclid", "distance": "euclid"},
             self.quantum,
             self.q_account_token,
             self.verbose,

--- a/pyriemann_qiskit/pipelines.py
+++ b/pyriemann_qiskit/pipelines.py
@@ -8,7 +8,7 @@ from qiskit_optimization.algorithms import CobylaOptimizer
 from pyriemann.estimation import XdawnCovariances, ERPCovariances
 from pyriemann.tangentspace import TangentSpace
 from pyriemann.preprocessing import Whitening
-from pyriemann_qiskit.utils.mean import is_qmean
+from pyriemann_qiskit.utils.utils import is_qfunction
 from pyriemann_qiskit.utils.filtering import NoDimRed
 from pyriemann_qiskit.utils.hyper_params_factory import (
     # gen_zz_feature_map,
@@ -384,7 +384,7 @@ class QuantumMDMWithRiemannianPipeline(BasePipeline):
     def _create_pipe(self):
         print(self.metric)
         print(self.metric["mean"])
-        if is_qmean(self.metric["mean"]):
+        if is_qfunction(self.metric["mean"]):
             if self.quantum:
                 covariances = XdawnCovariances(
                     nfilter=1, estimator="scm", xdawn_estimator="lwf"

--- a/pyriemann_qiskit/pipelines.py
+++ b/pyriemann_qiskit/pipelines.py
@@ -361,7 +361,7 @@ class QuantumMDMWithRiemannianPipeline(BasePipeline):
 
     def __init__(
         self,
-        metric={"mean": "logeuclid", "distance": "logeuclid_cpm"},
+        metric={"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
         quantum=True,
         q_account_token=None,
         verbose=True,
@@ -472,7 +472,7 @@ class QuantumMDMVotingClassifier(BasePipeline):
 
     def _create_pipe(self):
         clf_mean_logeuclid_dist_cpm = QuantumMDMWithRiemannianPipeline(
-            {"mean": "logeuclid", "distance": "logeuclid_cpm"},
+            {"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
             self.quantum,
             self.q_account_token,
             self.verbose,

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -46,5 +46,5 @@ __all__ = [
     "filter_subjects_by_incomplete_results",
     "add_moabb_dataframe_results_to_caches",
     "convert_caches_to_dataframes",
-    "utils"
+    "utils",
 ]

--- a/pyriemann_qiskit/utils/__init__.py
+++ b/pyriemann_qiskit/utils/__init__.py
@@ -20,6 +20,7 @@ from .firebase_connector import (
 )
 from . import distance
 from . import mean
+from . import utils
 
 __all__ = [
     "hyper_params_factory",
@@ -45,4 +46,5 @@ __all__ = [
     "filter_subjects_by_incomplete_results",
     "add_moabb_dataframe_results_to_caches",
     "convert_caches_to_dataframes",
+    "utils"
 ]

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -69,9 +69,9 @@ def qdistance_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
 def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     """Weights for Log-Euclidean distance to a convex hull of SPD matrices.
 
-    Weights for Log-Euclidean distance between a SPD matrix B and the convex hull of a set
-    of SPD matrices A [1]_, formulated as a Constraint Programming Model (CPM)
-    [2]_.
+    Weights for Log-Euclidean distance between a SPD matrix B
+    and the convex hull of a set of SPD matrices A [1]_,
+    formulated as a Constraint Programming Model (CPM) [2]_.
 
     Parameters
     ----------

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -13,13 +13,13 @@ from typing_extensions import deprecated
 
 @deprecated(
     "logeucl_dist_convex is deprecated and will be removed in 0.3.0; "
-    "please use distance_logeuclid_cpm."
+    "please use qdistance_logeuclid_to_convex_hull."
 )
 def logeucl_dist_convex():
     pass
 
 
-def distance_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
+def qdistance_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     """Log-Euclidean distance to a convex hull of SPD matrices.
 
     Log-Euclidean distance between a SPD matrix B and the convex hull of a set
@@ -57,7 +57,7 @@ def distance_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
         http://ibmdecisionoptimization.github.io/docplex-doc/cp/creating_model.html
 
     """
-    weights = weights_logeuclid_to_convex_hull_cpm(A, B, optimizer)
+    weights = weights_logeuclid_to_convex_hull(A, B, optimizer)
 
     # compute nearest matrix and distance
     C = mean_logeuclid(A, weights)
@@ -66,7 +66,7 @@ def distance_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
     return distance
 
 
-def weights_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
+def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     """Weights for Log-Euclidean distance to a convex hull of SPD matrices.
 
     Weights for Log-Euclidean distance between a SPD matrix B and the convex hull of a set
@@ -129,7 +129,7 @@ def weights_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
     return weights
 
 
-def weights_distance_cpm(
+def weights_distance(
     A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()
 ):
     """`distance` weights between a SPD and a set of SPD matrices.
@@ -185,11 +185,11 @@ def weights_distance_cpm(
     return weights
 
 
-def is_cpm_dist(string):
-    """Indicates if the distance is a CPM distance.
+def is_qdist(string):
+    """Indicates if the distance is a distance introduced in pyRiemann-qiskit.
 
-    Return True is "string" represents a Constraint Programming Model (CPM) [1]_
-    distance available in the library.
+    Return True is "string" represents a
+    distance introduced in pyRiemann-qiskit.
 
     Parameters
     ----------
@@ -198,8 +198,8 @@ def is_cpm_dist(string):
 
     Returns
     -------
-    is_cpm_dist : boolean
-        True if "string" represents a CPM distance available in the library.
+    is_q_dist : boolean
+        True if "string" represents a distance available in the library.
 
     Notes
     -----
@@ -211,13 +211,13 @@ def is_cpm_dist(string):
         http://ibmdecisionoptimization.github.io/docplex-doc/cp/creating_model.html
 
     """
-    return "_cpm" in string and string in distance_functions
+    return string[0] == "q" and string in distance_functions
 
 
-distance_functions["logeuclid_hull_cpm"] = weights_logeuclid_to_convex_hull_cpm
-distance_functions["euclid_cpm"] = lambda A, B: weights_distance_cpm(
+distance_functions["qlogeuclid_hull"] = weights_logeuclid_to_convex_hull
+distance_functions["qeuclid"] = lambda A, B: weights_distance(
     A, B, distance_euclid
 )
-distance_functions["logeuclid_cpm"] = lambda A, B: weights_distance_cpm(
+distance_functions["qlogeuclid"] = lambda A, B: weights_distance(
     A, B, distance_logeuclid
 )

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -33,7 +33,8 @@ def qdistance_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     B : ndarray, shape (n_channels, n_channels)
         SPD matrix.
     optimizer : pyQiskitOptimizer, default=ClassicalOptimizer()
-      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
+        An instance of
+        :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------
@@ -46,7 +47,6 @@ def qdistance_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     -----
     .. versionadded:: 0.2.0
 
-
     References
     ----------
     .. [1] \
@@ -58,8 +58,7 @@ def qdistance_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
 
     """
     weights = weights_logeuclid_to_convex_hull(A, B, optimizer)
-
-    # compute nearest matrix and distance
+    # compute nearest matrix
     C = mean_logeuclid(A, weights)
     distance = distance_logeuclid(C, B)
 
@@ -79,8 +78,9 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
         Set of SPD matrices.
     B : ndarray, shape (n_channels, n_channels)
         SPD matrix.
-    optimizer: pyQiskitOptimizer
-      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
+    optimizer : pyQiskitOptimizer, default=ClassicalOptimizer()
+        An instance of
+        :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------
@@ -93,7 +93,8 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     -----
     .. versionadded:: 0.0.4
     .. versionchanged:: 0.2.0
-        Add linear constraint on weights (sum = 1)
+        Rename from `logeucl_dist_convex` to `weights_logeuclid_to_convex_hull`.
+        Add linear constraint on weights (sum = 1).
 
     References
     ----------
@@ -113,16 +114,15 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
 
     prob = Model()
     optimizer = get_global_optimizer(optimizer)
-    # should be part of the optimizer
     w = optimizer.get_weights(prob, matrices)
 
     wtLogAtLogAw = prob.sum(
         w[i] * w[j] * log_prod(A[i], A[j]) for i in matrices for j in matrices
     )
     wLogBLogA = prob.sum(w[i] * log_prod(B, A[i]) for i in matrices)
-    objectives = wtLogAtLogAw - 2 * wLogBLogA
+    objective = wtLogAtLogAw - 2 * wLogBLogA
 
-    prob.set_objective("min", objectives)
+    prob.set_objective("min", objective)
     prob.add_constraint(prob.sum(w) == 1)
     weights = optimizer.solve(prob, reshape=False)
 
@@ -135,8 +135,7 @@ def _weights_distance(
     """`distance` weights between a SPD and a set of SPD matrices.
 
     `distance` weights between a SPD matrix B and each SPD matrix inside A,
-    formulated as a Constraint Programming Model (CPM)
-    [1]_.
+    formulated as a Constraint Programming Model (CPM) [1]_.
     The higher weight corresponds to the closer SPD matrix inside A,
     which is closer to B.
 
@@ -146,17 +145,17 @@ def _weights_distance(
         Set of SPD matrices.
     B : ndarray, shape (n_channels, n_channels)
         SPD matrix.
-    distance: Callable[[ndarray, ndarray], float]
-        One of the pyRiemann distance
-    optimizer: pyQiskitOptimizer
-      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
+    distance : Callable[[ndarray, ndarray], float]
+        One of the pyRiemann distance.
+    optimizer : pyQiskitOptimizer, default=ClassicalOptimizer()
+        An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------
     weights : ndarray, shape (n_matrices,)
-        it returns the optimized weights for the set of SPD matrices A.
+        Optimized weights for the set of SPD matrices A.
         The higher weight corresponds to the closer SPD matrix inside A,
-        which is closer to B
+        which is closer to B.
 
     Notes
     -----

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -69,7 +69,7 @@ def distance_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
 def weights_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
     """Weights for Log-Euclidean distance to a convex hull of SPD matrices.
 
-    Log-Euclidean weights between a SPD matrix B and the convex hull of a set
+    Weights for Log-Euclidean distance between a SPD matrix B and the convex hull of a set
     of SPD matrices A [1]_, formulated as a Constraint Programming Model (CPM)
     [2]_.
 

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -32,8 +32,8 @@ def qdistance_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
         Set of SPD matrices.
     B : ndarray, shape (n_channels, n_channels)
         SPD matrix.
-    optimizer: pyQiskitOptimizer
-      An instance of pyQiskitOptimizer.
+    optimizer : pyQiskitOptimizer, default=ClassicalOptimizer()
+      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -85,7 +85,7 @@ def weights_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
     Returns
     -------
     weights : ndarray, shape (n_matrices,)
-        it returns the optimized weights for the set of SPD matrices A.
+        Optimized weights for the set of SPD matrices A.
         Using these weights, the weighted Log-Euclidean mean of set A
         provides the matrix of the convex hull closest to matrix B.
 

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -129,7 +129,7 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     return weights
 
 
-def weights_distance(A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()):
+def _weights_distance(A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()):
     """`distance` weights between a SPD and a set of SPD matrices.
 
     `distance` weights between a SPD matrix B and each SPD matrix inside A,
@@ -213,7 +213,7 @@ def is_qdist(string):
 
 
 distance_functions["qlogeuclid_hull"] = weights_logeuclid_to_convex_hull
-distance_functions["qeuclid"] = lambda A, B: weights_distance(A, B, distance_euclid)
-distance_functions["qlogeuclid"] = lambda A, B: weights_distance(
+distance_functions["qeuclid"] = lambda A, B: _weights_distance(A, B, distance_euclid)
+distance_functions["qlogeuclid"] = lambda A, B: _weights_distance(
     A, B, distance_logeuclid
 )

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -67,7 +67,7 @@ def distance_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
 
 
 def weights_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
-    """Log-Euclidean weights to a convex hull of SPD matrices.
+    """Weights for Log-Euclidean distance to a convex hull of SPD matrices.
 
     Log-Euclidean weights between a SPD matrix B and the convex hull of a set
     of SPD matrices A [1]_, formulated as a Constraint Programming Model (CPM)

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -80,7 +80,7 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     B : ndarray, shape (n_channels, n_channels)
         SPD matrix.
     optimizer: pyQiskitOptimizer
-      An instance of pyQiskitOptimizer.
+      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------
@@ -149,7 +149,7 @@ def _weights_distance(
     distance: Callable[[ndarray, ndarray], float]
         One of the pyRiemann distance
     optimizer: pyQiskitOptimizer
-      An instance of pyQiskitOptimizer.
+      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -90,19 +90,6 @@ def distance_logeuclid_cpm(A, B, optimizer=ClassicalOptimizer(), return_weights=
     return distance
 
 
-_mdm_predict_distances_original = MDM._predict_distances
-
-
-def predict_distances(mdm, X):
-    if mdm.metric_dist == "logeuclid_cpm":
-        centroids = np.array(mdm.covmeans_)
-
-        weights = [
-            distance_logeuclid_cpm(centroids, x, return_weights=True)[1] for x in X
-        ]
-        return 1 - np.array(weights)
-    else:
-        return _mdm_predict_distances_original(mdm, X)
 
 
 def is_cpm_dist(string):
@@ -133,12 +120,4 @@ def is_cpm_dist(string):
     """
     return "_cpm" in string and string in distance_functions
 
-
-MDM._predict_distances = predict_distances
-
-# This is only for validation inside the MDM.
-# In fact, we override the _predict_distances method
-# inside MDM to directly use distance_logeuclid_cpm when the metric is "logeuclid_cpm"
-# This is due to the fact the the signature of this method is different from
-# the usual distance functions.
 distance_functions["logeuclid_cpm"] = distance_logeuclid_cpm

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -1,7 +1,11 @@
 import numpy as np
 from docplex.mp.model import Model
 from pyriemann_qiskit.utils.docplex import ClassicalOptimizer, get_global_optimizer
-from pyriemann.utils.distance import distance_functions, distance_logeuclid, distance_euclid
+from pyriemann.utils.distance import (
+    distance_functions,
+    distance_logeuclid,
+    distance_euclid,
+)
 from pyriemann.utils.base import logm
 from pyriemann.utils.mean import mean_logeuclid
 from typing_extensions import deprecated
@@ -124,7 +128,10 @@ def weights_logeuclid_to_convex_hull_cpm(A, B, optimizer=ClassicalOptimizer()):
 
     return weights
 
-def weights_distance_cpm(A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()):
+
+def weights_distance_cpm(
+    A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()
+):
     """`distance` weights between a SPD and a set of SPD matrices.
 
     `distance` weights between a SPD matrix B and each SPD matrix inside A,
@@ -169,9 +176,7 @@ def weights_distance_cpm(A, B, distance=distance_logeuclid, optimizer=ClassicalO
 
     w = optimizer.get_weights(prob, matrices)
 
-    objectif = prob.sum(
-        w[i] * distance(B, A[i]) for i in matrices
-    )
+    objectif = prob.sum(w[i] * distance(B, A[i]) for i in matrices)
 
     prob.set_objective("min", objectif)
     prob.add_constraint(prob.sum(w) == 1)
@@ -208,6 +213,11 @@ def is_cpm_dist(string):
     """
     return "_cpm" in string and string in distance_functions
 
+
 distance_functions["logeuclid_hull_cpm"] = weights_logeuclid_to_convex_hull_cpm
-distance_functions["euclid_cpm"] = lambda A, B: weights_distance_cpm(A, B, distance_euclid)
-distance_functions["logeuclid_cpm"] = lambda A, B: weights_distance_cpm(A, B, distance_logeuclid)
+distance_functions["euclid_cpm"] = lambda A, B: weights_distance_cpm(
+    A, B, distance_euclid
+)
+distance_functions["logeuclid_cpm"] = lambda A, B: weights_distance_cpm(
+    A, B, distance_logeuclid
+)

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -129,7 +129,9 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     return weights
 
 
-def _weights_distance(A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()):
+def _weights_distance(
+    A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()
+):
     """`distance` weights between a SPD and a set of SPD matrices.
 
     `distance` weights between a SPD matrix B and each SPD matrix inside A,

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -13,7 +13,7 @@ from typing_extensions import deprecated
 
 @deprecated(
     "logeucl_dist_convex is deprecated and will be removed in 0.3.0; "
-    "please use qdistance_logeuclid_to_convex_hull."
+    "please use weights_logeuclid_to_convex_hull."
 )
 def logeucl_dist_convex():
     pass

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -185,35 +185,6 @@ def _weights_distance(
     return weights
 
 
-def is_qdist(string):
-    """Indicates if the distance is a distance introduced in pyRiemann-qiskit.
-
-    Return True is "string" represents a
-    distance introduced in pyRiemann-qiskit.
-
-    Parameters
-    ----------
-    string: str
-        A string representation of the distance.
-
-    Returns
-    -------
-    is_q_dist : boolean
-        True if "string" represents a distance available in the library.
-
-    Notes
-    -----
-    .. versionadded:: 0.2.0
-
-    References
-    ----------
-    .. [1] \
-        http://ibmdecisionoptimization.github.io/docplex-doc/cp/creating_model.html
-
-    """
-    return string[0] == "q" and string in distance_functions
-
-
 distance_functions["qlogeuclid_hull"] = weights_logeuclid_to_convex_hull
 distance_functions["qeuclid"] = lambda A, B: _weights_distance(A, B, distance_euclid)
 distance_functions["qlogeuclid"] = lambda A, B: _weights_distance(

--- a/pyriemann_qiskit/utils/distance.py
+++ b/pyriemann_qiskit/utils/distance.py
@@ -129,9 +129,7 @@ def weights_logeuclid_to_convex_hull(A, B, optimizer=ClassicalOptimizer()):
     return weights
 
 
-def weights_distance(
-    A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()
-):
+def weights_distance(A, B, distance=distance_logeuclid, optimizer=ClassicalOptimizer()):
     """`distance` weights between a SPD and a set of SPD matrices.
 
     `distance` weights between a SPD matrix B and each SPD matrix inside A,
@@ -215,9 +213,7 @@ def is_qdist(string):
 
 
 distance_functions["qlogeuclid_hull"] = weights_logeuclid_to_convex_hull
-distance_functions["qeuclid"] = lambda A, B: weights_distance(
-    A, B, distance_euclid
-)
+distance_functions["qeuclid"] = lambda A, B: weights_distance(A, B, distance_euclid)
 distance_functions["qlogeuclid"] = lambda A, B: weights_distance(
     A, B, distance_logeuclid
 )

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -25,7 +25,7 @@ def set_global_optimizer(optimizer):
     Parameters
     ----------
     optimizer: pyQiskitOptimizer
-      An instance of pyQiskitOptimizer.
+      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Notes
     -----
@@ -40,7 +40,7 @@ def get_global_optimizer(default):
     Parameters
     ----------
     default: pyQiskitOptimizer
-      An instance of pyQiskitOptimizer.
+      An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
       It will be returned by default if the global optimizer is None.
 
     Returns

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -28,7 +28,7 @@ def qmean_euclid(X, sample_weight=None, optimizer=ClassicalOptimizer()):
         Weights for each matrix. Never used in practice.
         It is kept only for standardization with pyRiemann.
     optimizer : pyQiskitOptimizer
-        An instance of pyQiskitOptimizer.
+        An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------
@@ -89,7 +89,7 @@ def qmean_logeuclid(
         Weights for each matrix. Never used in practice.
         It is kept only for standardization with pyRiemann.
     optimizer : pyQiskitOptimizer
-        An instance of pyQiskitOptimizer.
+        An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
     -------

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -130,7 +130,7 @@ def is_qmean(string):
     Returns
     -------
     is_qmean : boolean
-        True if "string" represents a mean aailable in the library.
+        True if "string" represents a mean available in the library.
 
     Notes
     -----

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -27,7 +27,7 @@ def qmean_euclid(X, sample_weight=None, optimizer=ClassicalOptimizer()):
     sample_weights : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix. Never used in practice.
         It is kept only for standardization with pyRiemann.
-    optimizer : pyQiskitOptimizer
+    optimizer : pyQiskitOptimizer, default=ClassicalOptimizer()
         An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns
@@ -41,8 +41,8 @@ def qmean_euclid(X, sample_weight=None, optimizer=ClassicalOptimizer()):
     .. versionchanged:: 0.0.4
         Add regularization of the results.
     .. versionchanged:: 0.2.0
-        Rename from `fro_mean_convex` to `qmean_euclid`
-        Remove shrinkage
+        Rename from `fro_mean_convex` to `qmean_euclid`.
+        Remove shrinkage.
 
     References
     ----------
@@ -88,7 +88,7 @@ def qmean_logeuclid(
     sample_weights : None | ndarray, shape (n_matrices,), default=None
         Weights for each matrix. Never used in practice.
         It is kept only for standardization with pyRiemann.
-    optimizer : pyQiskitOptimizer
+    optimizer : pyQiskitOptimizer, default=ClassicalOptimizer()
         An instance of :class:`pyriemann_qiskit.utils.docplex.pyQiskitOptimizer`.
 
     Returns

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -116,29 +116,5 @@ def qmean_logeuclid(
     return expm(result)
 
 
-def is_qmean(string):
-    """Indicates if the mean is a mean introduced in this library.
-
-    Return True is "string" represents a
-    mean available in the library.
-
-    Parameters
-    ----------
-    string: str
-        A string representation of the mean.
-
-    Returns
-    -------
-    is_qmean : boolean
-        True if "string" represents a mean available in the library.
-
-    Notes
-    -----
-    .. versionadded:: 0.2.0
-
-    """
-    return string[0] == "q" and string in mean_functions
-
-
 mean_functions["qeuclid"] = qmean_euclid
 mean_functions["qlogeuclid"] = qmean_logeuclid

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -8,13 +8,13 @@ from qiskit_optimization.algorithms import ADMMOptimizer
 
 @deprecated(
     "fro_mean_convex is deprecated and will be removed in 0.3.0; "
-    "please use mean_euclid_cpm."
+    "please use qmean_euclid."
 )
 def fro_mean_convex():
     pass
 
 
-def mean_euclid_cpm(X, sample_weight=None, optimizer=ClassicalOptimizer()):
+def qmean_euclid(X, sample_weight=None, optimizer=ClassicalOptimizer()):
     """Euclidean mean with Constraint Programming Model.
 
     Constraint Programming Model (CPM) [1]_ formulation of the mean
@@ -41,7 +41,7 @@ def mean_euclid_cpm(X, sample_weight=None, optimizer=ClassicalOptimizer()):
     .. versionchanged:: 0.0.4
         Add regularization of the results.
     .. versionchanged:: 0.2.0
-        Rename from `fro_mean_convex` to `mean_euclid_cpm`
+        Rename from `fro_mean_convex` to `qmean_euclid`
         Remove shrinkage
 
     References
@@ -73,7 +73,7 @@ def mean_euclid_cpm(X, sample_weight=None, optimizer=ClassicalOptimizer()):
     return result
 
 
-def mean_logeuclid_cpm(
+def qmean_logeuclid(
     X, sample_weight=None, optimizer=ClassicalOptimizer(optimizer=ADMMOptimizer())
 ):
     """Log-Euclidean mean with Constraint Programming Model.
@@ -112,14 +112,14 @@ def mean_logeuclid_cpm(
     """
 
     log_X = logm(X)
-    result = mean_euclid_cpm(log_X, sample_weight, optimizer)
+    result = qmean_euclid(log_X, sample_weight, optimizer)
     return expm(result)
 
 
-def is_cpm_mean(string):
-    """Indicates if the mean is a CPM mean.
+def is_qmean(string):
+    """Indicates if the mean is a mean introduced in this library.
 
-    Return True is "string" represents a Constraint Programming Model (CPM) [1]_
+    Return True is "string" represents a 
     mean available in the library.
 
     Parameters
@@ -129,21 +129,16 @@ def is_cpm_mean(string):
 
     Returns
     -------
-    is_cpm_mean : boolean
-        True if "string" represents a CPM mean aailable in the library.
+    is_qmean : boolean
+        True if "string" represents a mean aailable in the library.
 
     Notes
     -----
     .. versionadded:: 0.2.0
 
-    References
-    ----------
-    .. [1] \
-        http://ibmdecisionoptimization.github.io/docplex-doc/cp/creating_model.html
-
     """
-    return "_cpm" in string and string in mean_functions
+    return string[0] == "q" and string in mean_functions
 
 
-mean_functions["euclid_cpm"] = mean_euclid_cpm
-mean_functions["logeuclid_cpm"] = mean_logeuclid_cpm
+mean_functions["qeuclid"] = qmean_euclid
+mean_functions["qlogeuclid"] = qmean_logeuclid

--- a/pyriemann_qiskit/utils/mean.py
+++ b/pyriemann_qiskit/utils/mean.py
@@ -119,7 +119,7 @@ def qmean_logeuclid(
 def is_qmean(string):
     """Indicates if the mean is a mean introduced in this library.
 
-    Return True is "string" represents a 
+    Return True is "string" represents a
     mean available in the library.
 
     Parameters

--- a/pyriemann_qiskit/utils/utils.py
+++ b/pyriemann_qiskit/utils/utils.py
@@ -1,0 +1,26 @@
+from .mean import mean_functions
+from .distance import distance_functions
+
+def is_qfunction(string):
+    """Indicates if the function is a mean or a distance introduced in this library.
+
+    Return True is "string" represents a
+    mean or a distance introduced in this library.
+
+    Parameters
+    ----------
+    string: str
+        A string representation of the mean/distance.
+
+    Returns
+    -------
+    is_qfunction : boolean
+        True if "string" represents a mean or a distance introduced in this library.
+
+    Notes
+    -----
+    .. versionadded:: 0.2.0
+
+    """
+    return string[0] == "q" and\
+        ( (string in mean_functions) or (string in distance_functions) )

--- a/pyriemann_qiskit/utils/utils.py
+++ b/pyriemann_qiskit/utils/utils.py
@@ -1,6 +1,7 @@
 from .mean import mean_functions
 from .distance import distance_functions
 
+
 def is_qfunction(string):
     """Indicates if the function is a mean or a distance introduced in this library.
 
@@ -22,5 +23,6 @@ def is_qfunction(string):
     .. versionadded:: 0.2.0
 
     """
-    return string[0] == "q" and\
-        ( (string in mean_functions) or (string in distance_functions) )
+    return string[0] == "q" and (
+        (string in mean_functions) or (string in distance_functions)
+    )

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -5,6 +5,7 @@ from pyriemann_qiskit.utils import (
     NaiveQAOAOptimizer,
 )
 from pyriemann_qiskit.utils.distance import distance_logeuclid_cpm
+from pyriemann_qiskit.classification import QuanticMDM
 from pyriemann_qiskit.datasets import get_mne_sample
 from pyriemann.classification import MDM
 from pyriemann.estimation import XdawnCovariances
@@ -15,7 +16,7 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 def test_performance():
     metric = {"mean": "logeuclid", "distance": "logeuclid_cpm"}
 
-    clf = make_pipeline(XdawnCovariances(), MDM(metric=metric))
+    clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False))
     skf = StratifiedKFold(n_splits=3)
     covset, labels = get_mne_sample()
     score = cross_val_score(clf, covset, labels, cv=skf, scoring="roc_auc")

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -22,7 +22,6 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
     ],
 )
 def test_performance(metric):
-
     clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False))
     skf = StratifiedKFold(n_splits=3)
     covset, labels = get_mne_sample()

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -7,7 +7,6 @@ from pyriemann_qiskit.utils import (
 from pyriemann_qiskit.utils.distance import weights_logeuclid_to_convex_hull
 from pyriemann_qiskit.classification import QuanticMDM
 from pyriemann_qiskit.datasets import get_mne_sample
-from pyriemann.classification import MDM
 from pyriemann.estimation import XdawnCovariances
 from sklearn.pipeline import make_pipeline
 from sklearn.model_selection import StratifiedKFold, cross_val_score

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -4,7 +4,7 @@ from pyriemann_qiskit.utils import (
     ClassicalOptimizer,
     NaiveQAOAOptimizer,
 )
-from pyriemann_qiskit.utils.distance import distance_logeuclid_cpm
+from pyriemann_qiskit.utils.distance import distance_logeuclid_to_convex_hull_cpm
 from pyriemann_qiskit.classification import QuanticMDM
 from pyriemann_qiskit.datasets import get_mne_sample
 from pyriemann.classification import MDM
@@ -14,7 +14,7 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 
 def test_performance():
-    metric = {"mean": "logeuclid", "distance": "logeuclid_cpm"}
+    metric = {"mean": "logeuclid", "distance": "logeuclid_hull_cpm"}
 
     clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False))
     skf = StratifiedKFold(n_splits=3)
@@ -29,6 +29,6 @@ def test_distance_logeuclid_cpm(optimizer):
     X_1 = X_0 + 1
     X = np.stack((X_0, X_1))
     y = (X_0 + X_1) / 3
-    _, weights = distance_logeuclid_cpm(X, y, optimizer=optimizer, return_weights=True)
+    _, weights = distance_logeuclid_to_convex_hull_cpm(X, y, optimizer=optimizer, return_weights=True)
     distances = 1 - weights
     assert distances.argmin() == 0

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -4,7 +4,7 @@ from pyriemann_qiskit.utils import (
     ClassicalOptimizer,
     NaiveQAOAOptimizer,
 )
-from pyriemann_qiskit.utils.distance import distance_logeuclid_to_convex_hull_cpm
+from pyriemann_qiskit.utils.distance import weights_logeuclid_to_convex_hull_cpm
 from pyriemann_qiskit.classification import QuanticMDM
 from pyriemann_qiskit.datasets import get_mne_sample
 from pyriemann.classification import MDM
@@ -13,10 +13,17 @@ from sklearn.pipeline import make_pipeline
 from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 
-def test_performance():
-    metric = {"mean": "logeuclid", "distance": "logeuclid_hull_cpm"}
+@pytest.mark.parametrize(
+    "kernel",
+    [
+        ({"mean": "euclid", "distance": "euclid_cpm"}, None),
+        ({"mean": "logeuclid", "distance": "logeuclid_hull_cpm"}, None),
+    ],
+)
+def test_performance(kernel):
+    metric, regularization = kernel
 
-    clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False))
+    clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False, regularization=regularization))
     skf = StratifiedKFold(n_splits=3)
     covset, labels = get_mne_sample()
     score = cross_val_score(clf, covset, labels, cv=skf, scoring="roc_auc")
@@ -24,11 +31,11 @@ def test_performance():
 
 
 @pytest.mark.parametrize("optimizer", [ClassicalOptimizer(), NaiveQAOAOptimizer()])
-def test_distance_logeuclid_cpm(optimizer):
+def test_distance_logeuclid_to_convex_hull_cpm(optimizer):
     X_0 = np.array([[0.9, 1.1], [0.9, 1.1]])
     X_1 = X_0 + 1
     X = np.stack((X_0, X_1))
     y = (X_0 + X_1) / 3
-    _, weights = distance_logeuclid_to_convex_hull_cpm(X, y, optimizer=optimizer, return_weights=True)
+    weights = weights_logeuclid_to_convex_hull_cpm(X, y, optimizer=optimizer)
     distances = 1 - weights
     assert distances.argmin() == 0

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -4,7 +4,7 @@ from pyriemann_qiskit.utils import (
     ClassicalOptimizer,
     NaiveQAOAOptimizer,
 )
-from pyriemann_qiskit.utils.distance import weights_logeuclid_to_convex_hull_cpm
+from pyriemann_qiskit.utils.distance import weights_logeuclid_to_convex_hull
 from pyriemann_qiskit.classification import QuanticMDM
 from pyriemann_qiskit.datasets import get_mne_sample
 from pyriemann.classification import MDM
@@ -16,9 +16,9 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 @pytest.mark.parametrize(
     "metric",
     [
-        {"mean": "euclid", "distance": "euclid_cpm"},
-        {"mean": "logeuclid", "distance": "logeuclid_cpm"},
-        {"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
+        {"mean": "euclid", "distance": "qeuclid"},
+        {"mean": "logeuclid", "distance": "qlogeuclid"},
+        {"mean": "logeuclid", "distance": "qlogeuclid_hull"},
     ],
 )
 def test_performance(metric):
@@ -35,6 +35,6 @@ def test_distance_logeuclid_to_convex_hull_cpm(optimizer):
     X_1 = X_0 + 1
     X = np.stack((X_0, X_1))
     y = (X_0 + X_1) / 3
-    weights = weights_logeuclid_to_convex_hull_cpm(X, y, optimizer=optimizer)
+    weights = weights_logeuclid_to_convex_hull(X, y, optimizer=optimizer)
     distances = 1 - weights
     assert distances.argmin() == 0

--- a/tests/test_utils_distance.py
+++ b/tests/test_utils_distance.py
@@ -14,16 +14,16 @@ from sklearn.model_selection import StratifiedKFold, cross_val_score
 
 
 @pytest.mark.parametrize(
-    "kernel",
+    "metric",
     [
-        ({"mean": "euclid", "distance": "euclid_cpm"}, None),
-        ({"mean": "logeuclid", "distance": "logeuclid_hull_cpm"}, None),
+        {"mean": "euclid", "distance": "euclid_cpm"},
+        {"mean": "logeuclid", "distance": "logeuclid_cpm"},
+        {"mean": "logeuclid", "distance": "logeuclid_hull_cpm"},
     ],
 )
-def test_performance(kernel):
-    metric, regularization = kernel
+def test_performance(metric):
 
-    clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False, regularization=regularization))
+    clf = make_pipeline(XdawnCovariances(), QuanticMDM(metric=metric, quantum=False))
     skf = StratifiedKFold(n_splits=3)
     covset, labels = get_mne_sample()
     score = cross_val_score(clf, covset, labels, cv=skf, scoring="roc_auc")

--- a/tests/test_utils_mean.py
+++ b/tests/test_utils_mean.py
@@ -4,7 +4,7 @@ from pyriemann.utils.mean import mean_euclid, mean_logeuclid
 from pyriemann.estimation import XdawnCovariances, Shrinkage
 from sklearn.pipeline import make_pipeline
 from sklearn.model_selection import StratifiedKFold, cross_val_score
-from pyriemann_qiskit.utils.mean import mean_euclid_cpm, mean_logeuclid_cpm
+from pyriemann_qiskit.utils.mean import qmean_euclid, qmean_logeuclid
 from pyriemann_qiskit.utils import ClassicalOptimizer, NaiveQAOAOptimizer
 from pyriemann_qiskit.classification import QuanticMDM
 from pyriemann_qiskit.datasets import get_mne_sample
@@ -14,8 +14,8 @@ from qiskit_optimization.algorithms import ADMMOptimizer
 @pytest.mark.parametrize(
     "kernel",
     [
-        ({"mean": "euclid_cpm", "distance": "euclid"}, Shrinkage(shrinkage=0.9)),
-        ({"mean": "logeuclid_cpm", "distance": "logeuclid"}, Shrinkage(shrinkage=0.9)),
+        ({"mean": "qeuclid", "distance": "euclid"}, Shrinkage(shrinkage=0.9)),
+        ({"mean": "qlogeuclid", "distance": "logeuclid"}, Shrinkage(shrinkage=0.9)),
     ],
 )
 def test_performance(kernel):
@@ -33,7 +33,7 @@ def test_performance(kernel):
 
 
 @pytest.mark.parametrize(
-    "means", [(mean_euclid, mean_euclid_cpm), (mean_logeuclid, mean_logeuclid_cpm)]
+    "means", [(mean_euclid, qmean_euclid), (mean_logeuclid, qmean_logeuclid)]
 )
 def test_analytic_vs_cpm_mean(get_covmats, means):
     """Test that analytic and cpm mean returns close results"""
@@ -45,7 +45,7 @@ def test_analytic_vs_cpm_mean(get_covmats, means):
     assert np.allclose(C, C_analytic, atol=0.00001)
 
 
-@pytest.mark.parametrize("mean", [mean_euclid_cpm, mean_logeuclid_cpm])
+@pytest.mark.parametrize("mean", [qmean_euclid, qmean_logeuclid])
 def test_mean_cpm_shape(get_covmats, mean):
     """Test the shape of mean"""
     n_trials, n_channels = 5, 3
@@ -58,7 +58,7 @@ def test_mean_cpm_shape(get_covmats, mean):
     "optimizer",
     [ClassicalOptimizer(optimizer=ADMMOptimizer()), NaiveQAOAOptimizer()],
 )
-@pytest.mark.parametrize("mean", [mean_euclid_cpm])
+@pytest.mark.parametrize("mean", [qmean_euclid])
 def test_mean_cpm_all_zeros(optimizer, mean):
     """Test that the mean of covariance matrices containing zeros
     is a matrix filled with zeros"""
@@ -72,7 +72,7 @@ def test_mean_cpm_all_zeros(optimizer, mean):
     "optimizer",
     [ClassicalOptimizer(optimizer=ADMMOptimizer()), NaiveQAOAOptimizer()],
 )
-@pytest.mark.parametrize("mean", [mean_euclid_cpm])
+@pytest.mark.parametrize("mean", [qmean_euclid])
 def test_mean_cpm_all_ones(optimizer, mean):
     """Test that the mean of covariance matrices containing ones
     is a matrix filled with ones"""
@@ -86,7 +86,7 @@ def test_mean_cpm_all_ones(optimizer, mean):
     "optimizer",
     [ClassicalOptimizer(optimizer=ADMMOptimizer()), NaiveQAOAOptimizer()],
 )
-@pytest.mark.parametrize("mean", [mean_euclid_cpm])
+@pytest.mark.parametrize("mean", [qmean_euclid])
 def test_mean_cpm_all_equals(optimizer, mean):
     """Test that the mean of covariance matrices filled with the same value
     is a matrix identical to the input"""
@@ -100,7 +100,7 @@ def test_mean_cpm_all_equals(optimizer, mean):
     "optimizer",
     [ClassicalOptimizer(optimizer=ADMMOptimizer()), NaiveQAOAOptimizer()],
 )
-@pytest.mark.parametrize("mean", [mean_euclid_cpm])
+@pytest.mark.parametrize("mean", [qmean_euclid])
 def test_mean_cpm_mixed(optimizer, mean):
     """Test that the mean of covariances matrices with zero and ones
     is a matrix filled with 0.5"""


### PR DESCRIPTION
This PR:
- moves the workaround `_predict_distances` from the `distance` to the `classification` module.
- changes the workaround, so that we do not override the `_predict_distances` of the MDM class but only the one of a particular instance.
- separate computation of distances from weights
- rename `dist_logeuclid_cpm` to `dist_logeuclid_to_convex_hull_cpm`
- add toy functions `euclid_cpm` and `logeuclid_cpm` (the idea would be rather to re-implement the recursion in the pyRiemann distance module in the CPM way)
- add warnings concerning the use of CPM distances with MDM.

