### PR TITLE
Add pandas to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scipy==1.11.4
 docplex>=2.21.207
 firebase_admin==6.4.0
 tqdm
+pandas

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(name='pyriemann-qiskit',
                         'docplex>=2.21.207',
                         'firebase_admin==6.4.0',
                         'scikit-learn==1.3.2',
-                        'tqdm'
+                        'tqdm',
+                        'pandas'
                         ],
       extras_require={'docs': [
                                 'sphinx-gallery',


### PR DESCRIPTION
`pandas` is used in several files (visualization/art.py, utils/firebase_connector.py)
but is not in requirements, generating an error when using pyRiemann-qiskit.