### PR TITLE
Deprecate cov_to_corr_matrix

### DIFF
--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -13,7 +13,8 @@ from qiskit.algorithms import QAOA
 from qiskit_optimization.algorithms import CobylaOptimizer, MinimumEigenOptimizer
 from qiskit_optimization.converters import IntegerToBinary
 from qiskit_optimization.translators import from_docplex_mp
-from pyriemann_qiskit.utils import cov_to_corr_matrix, get_simulator
+from pyriemann.utils.covariance import normalize
+from pyriemann_qiskit.utils import get_simulator
 
 
 _global_optimizer = [None]
@@ -460,7 +461,7 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
     """
 
     def convert_covmat(self, covmat):
-        corr = cov_to_corr_matrix(covmat)
+        corr = normalize(covmat, "corr")
         return np.round(corr * self.upper_bound, 0)
 
     """Helper to create a docplex representation of a

--- a/pyriemann_qiskit/utils/math.py
+++ b/pyriemann_qiskit/utils/math.py
@@ -1,9 +1,14 @@
 """Module for mathematical helpers"""
 
-from pyriemann.utils.covariance import normalize
 import numpy as np
+from pyriemann.utils.covariance import normalize
+from pyriemann.utils import deprecated
 
 
+@deprecated(
+    "cov_to_corr_matrix is deprecated and will be removed in 0.4.0; "
+    "please use pyriemann.utils.covariance.normalize."
+)
 def cov_to_corr_matrix(covmat):
     """Convert covariance matrices to correlation matrices.
 


### PR DESCRIPTION
cov_to_corr_matrix is deprecated and will be removed in 0.4.0; please use pyriemann.utils.covariance.normalize