### PR TITLE
Remove EGG from docker-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,27 +12,12 @@ RUN python -m pip install --upgrade pip
 RUN apt-get -y install --fix-missing git-core
 RUN apt-get -y install build-essential
 
-RUN pip install urllib3==2.1.0
-RUN pip install requests==2.32.2
-RUN pip install "numpy<1.24"
-RUN python setup.py develop
+RUN pip install .
 RUN pip install .[docs]
 RUN pip install .[tests]
 
 ## Creating folders for mne data
 RUN mkdir /root/mne_data
 RUN mkdir /home/mne_data
-
-## Workaround for firestore
-RUN pip install google_cloud_firestore==2.16.0
-### Missing __init__ file in protobuf
-RUN touch /usr/local/lib/python3.9/site-packages/protobuf-4.25.3-py3.9.egg/google/__init__.py
-## google.cloud.location is never used in these files, and is missing in path.
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.9/site-packages/google_cloud_firestore-2.16.0-py3.9.egg/google/cloud/firestore_v1/services/firestore/client.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.9/site-packages/google_cloud_firestore-2.16.0-py3.9.egg/google/cloud/firestore_v1/services/firestore/transports/base.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.9/site-packages/google_cloud_firestore-2.16.0-py3.9.egg/google/cloud/firestore_v1/services/firestore/transports/grpc.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.9/site-packages/google_cloud_firestore-2.16.0-py3.9.egg/google/cloud/firestore_v1/services/firestore/transports/grpc_asyncio.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.9/site-packages/google_cloud_firestore-2.16.0-py3.9.egg/google/cloud/firestore_v1/services/firestore/transports/rest.py'
-RUN sed -i 's/from google.cloud.location import locations_pb2//g' '/usr/local/lib/python3.9/site-packages/google_cloud_firestore-2.16.0-py3.9.egg/google/cloud/firestore_v1/services/firestore/async_client.py'
 
 ENTRYPOINT [ "python", "/examples/ERP/classify_P300_bi.py" ]


### PR DESCRIPTION
EGG format is being deprecated.
I am removing from the Dockerfile all references to EGG. 