### PR TITLE
fix:Cobyla is not always the classical optimizer

### DIFF
--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -655,9 +655,7 @@ def _get_docplex_optimizer_from_params_bag(
                 optimizer=qaoa_optimizer,
             )
     else:
-        logger._log(
-            f"Using ClassicalOptimizer ({type(classical_optimizer).__name__})"
-        )
+        logger._log(f"Using ClassicalOptimizer ({type(classical_optimizer).__name__})")
         return ClassicalOptimizer(classical_optimizer)
 
 

--- a/pyriemann_qiskit/classification.py
+++ b/pyriemann_qiskit/classification.py
@@ -655,7 +655,9 @@ def _get_docplex_optimizer_from_params_bag(
                 optimizer=qaoa_optimizer,
             )
     else:
-        logger._log("Using ClassicalOptimizer (COBYLA)")
+        logger._log(
+            f"Using ClassicalOptimizer ({type(classical_optimizer).__name__})"
+        )
         return ClassicalOptimizer(classical_optimizer)
 
 


### PR DESCRIPTION
COBYLA was hard-coded in the logs, whereas it can be any type of optimizer. 
This PR intends to fix this by printing the real name of the optimizer.