### PR TITLE
Fix :class:`pyriemann_qiskit.utils.filtering.ChannelSelection` 

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -5,6 +5,16 @@
 What's new in the package
 =========================
 
+
+
+Develop branch
+----------------
+
+- Fix :class:`pyriemann_qiskit.utils.filtering.ChannelSelection` that caused incorrect channel selection
+
+
+
+
 v0.4.0
 ------
 

--- a/pyriemann_qiskit/utils/filtering.py
+++ b/pyriemann_qiskit/utils/filtering.py
@@ -166,19 +166,8 @@ class ChannelSelection(TransformerMixin):
         covs = Covariances(estimator=self.cov_est).fit_transform(X)
         # Get the average covariance between the channels.
         mean_cov = np.mean(covs, axis=0)
-        n_feats, _ = mean_cov.shape
         # Select the `n_channels` channels having the maximum covariances.
-        all_max = []
-        for i in range(n_feats):
-            for j in range(i, n_feats):
-                self._chs_idx = ChannelSelection._get_indices(all_max, mean_cov)
-
-                if len(self._chs_idx) < self.n_channels:
-                    all_max.append(mean_cov[i, j])
-                else:
-                    if mean_cov[i, j] > max(all_max):
-                        all_max[np.argmin(all_max)] = mean_cov[i, j]
-
+        self._chs_idx = np.argpartition(np.max(mean_cov, axis = 0), -self.n_channels, axis=None)[-self.n_channels:]
         return self
 
     def transform(self, X, **kwargs):


### PR DESCRIPTION
Fix :class:`pyriemann_qiskit.utils.filtering.ChannelSelection` that caused incorrect channel selection
Details: https://github.com/NeuroTechX/moabb/pull/685