### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This library is part of the [Qiskit Ecosystem](https://qiskit.org/ecosystem)
 ## Installation
 
 _We recommend the use of [Anaconda](https://www.anaconda.com/) to manage python
-environements._
+environments._
 
 `pyRiemann-qiskit` currently supports Windows, Mac and Linux OS with **Python 10 - 3.12**.
 
@@ -105,7 +105,7 @@ pip install pyriemann-qiskit
 ```
 
 The development version can be installed by cloning this repository and installing the
-package on your local machine using the `setup.py` script. We recommand to do it using
+package on your local machine using the `setup.py` script. We recommend to do it using
 `pip`:
 
 ```
@@ -157,7 +157,7 @@ python examples\ERP\classify_P300_bi.py
 ### Installation with docker
 
 We also offer the possibility to set up the dev environment within docker. To this end, we
-recommand to use `vscode` with the `Remote Containers` extension from Microsoft.
+recommend to use `vscode` with the `Remote Containers` extension from Microsoft.
 
 Once the installation is successful, just open the project in `vscode` and enter `F1`. In
 the search bar that opens, type `Rebuild and Reopen Container`.

--- a/benchmarks/heavy_benchmark.py
+++ b/benchmarks/heavy_benchmark.py
@@ -6,7 +6,7 @@ Benchmark Alpha
 A benchmark on a predefined list of databases for P300 and Motor Imagery (MI).
 
 Currently it requires the latest version of MOABB (from Github) where:
-    - cache_config is availabe for WithinSessionEvaluation|()
+    - cache_config is available for WithinSessionEvaluation|()
     - bug 514 is fixed: https://github.com/NeuroTechX/moabb/issues/514
 
 Adapts both the pipeline and the paradigms depending on the evaluated database.
@@ -86,7 +86,7 @@ def benchmark_alpha(
     evaluation_type: Default = "withinsession"
         Two options are available: "withinsession" and "crosssubject".
     max_n_subjects : int, default = -1
-        The maxmium number of subjects to be used per database.
+        The maximum number of subjects to be used per database.
     overwrite : bool, optional
         Set to True if we want to overwrite cached results.
     n_jobs : int, default=12

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -4,7 +4,7 @@ Installing pyRiemann-qiskit
 ===========================
 
 _We recommend the use of [Anaconda](https://www.anaconda.com/) to manage python
-environements._
+environments._
 
 `pyRiemann-qiskit` currently supports Windows, Mac and Linux OS with Python 3.10 - 3.12.
 

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -3,7 +3,7 @@
 Introduction to pyRiemann-qiskit
 ================================
 
-Litterature on quantum computing suggests it may offer an advantage as compared
+Literature on quantum computing suggests it may offer an advantage as compared
 with classical computing in terms of computational time and outcomes, such as
 for pattern recognition or when using limited training sets [1]_ [2]_.
 
@@ -16,13 +16,13 @@ quantum algorithm seamless.
 
 Qiskit implements a quantum version of support vector
 -like classifiers, known as quantum-enhanced support vector classifier (QSVC)
-and varitional quantum classifier (VQC) [4]_. These classifiers likely offer
+and variational quantum classifier (VQC) [4]_. These classifiers likely offer
 an advantage over classical SVM in situations where the classification task
 is complex. Task complexity is raised by the encoding of the data into a
 quantum state, the number of available data and the quality of the data. An initial
 study is available in [5]_, and it can be downloaded from `here
 <https://github.com/pyRiemann/pyRiemann-qiskit/blob/main/doc/Presentations/QuantumERPClassification.pdf>`_.
-Although there is no study on this topic at the time of writting,
+Although there is no study on this topic at the time of writing,
 this could be an interesting research direction to investigate BCI illiteracy.
 
 pyRiemann-qiskit implements a wrapper around QSVC and VQC, to use quantum

--- a/examples/ERP/noplot_autoencoders_example.py
+++ b/examples/ERP/noplot_autoencoders_example.py
@@ -106,7 +106,7 @@ n_components, n_times = 8, 64
 pipelines["QNN+LDA"] = make_pipeline(
     ChannelSelection(n_channels=n_components),
     Vectorizer(),
-    # Use COBYLA with only 1 iteration (this is for runnin in Ci/Cd)
+    # Use COBYLA with only 1 iteration (this is for running in Ci/Cd)
     BasicQnnAutoencoder(
         num_latent=n_components,
         num_trash=1,

--- a/examples/ERP/noplot_firebase_moabb.py
+++ b/examples/ERP/noplot_firebase_moabb.py
@@ -115,7 +115,7 @@ pipelines["RG+LDA"] = make_pipeline(
 )
 
 # We cache the results on Firebase.
-# But you can skip all cache functions bellow if you want.
+# But you can skip all cache functions below if you want.
 caches = generate_caches(datasets, pipelines)
 
 # This method remove a subject in a dataset if we already have evaluated

--- a/examples/other_datasets/plot_financial_data.py
+++ b/examples/other_datasets/plot_financial_data.py
@@ -6,7 +6,7 @@ Suspicious financial activity detection using quantum computer
 In this example, we will illustrate the use of Riemannian geometry and quantum
 computing for the detection of suspicious activity on financial data [1]_.
 
-The dataset contains synthethic data generated from a real dataset
+The dataset contains synthetic data generated from a real dataset
 of CaixaBank’s express loans [2]_.
 Each entry contains, for example, the date and amount of the loan request,
 the client identification number and the creation date of the account.
@@ -14,7 +14,7 @@ A loan is tagged with either tentative or confirmation of fraud, when a
 fraudster has impersonates the client to claim the loan and steal the client
 funds.
 
-Once the fraud is caracterized, a complex task is to identify whether or not a
+Once the fraud is characterized, a complex task is to identify whether or not a
 collusion is taking place. One fraudster can for example corrupt a client
 having already a good history with the bank.
 The fraud can also involves a bank agent who is mandated by the client.
@@ -169,7 +169,7 @@ print(features.head())
 print(f"number of fraudulent loans: {target[target == 1].size}")
 print(f"number of genuine loans: {target[target == 0].size}")
 
-# Simple treatement for NaN value
+# Simple treatment for NaN value
 features.fillna(method="ffill", inplace=True)
 
 # Convert date value to linux time
@@ -185,7 +185,7 @@ le.fit(features["IP_TERMINAL"].astype("category"))
 features["IP_TERMINAL"] = le.transform(features["IP_TERMINAL"].astype("category"))
 
 # ... and create an 'index' column in the dataset
-# Note: this is done only for progamming reasons, due to our implementation
+# Note: this is done only for programming reasons, due to our implementation
 # of the `ToEpochs` transformer (see below)
 features["index"] = features.index
 
@@ -425,7 +425,7 @@ print(
 #
 # 1) We have the no-aware ERP method (namely RandomForest)
 #    to predict whether or not the transaction is a fraud;
-# 2) If the fraud is caracterized, we use the QSVC pipeline to
+# 2) If the fraud is characterized, we use the QSVC pipeline to
 #    predict whether or not it is a collusion.
 
 

--- a/examples/toys_dataset/plot_quantum_art_vqc.py
+++ b/examples/toys_dataset/plot_quantum_art_vqc.py
@@ -36,7 +36,7 @@ fig.suptitle("VQC weights variability")
 
 # We will compute weight variability for different number of samples
 for i, n_samples in enumerate([2, 20]):
-    # ... and for differente number of parameters.
+    # ... and for different number of parameters.
     # (n_reps controls the number of parameters inside the circuit)
     for j, n_reps in enumerate([1, 3]):
         # instanciate VQC.

--- a/pyriemann_qiskit/classification/wrappers.py
+++ b/pyriemann_qiskit/classification/wrappers.py
@@ -292,7 +292,7 @@ class QuanticSVM(QuanticClassifierBase):
     This class implements a support-vector machine (SVM) classifier [1]_,
     called SVC, on a quantum machine [2]_.
     Note that if `quantum` parameter is set to `False`
-    then a classical SVC will be perfomed instead.
+    then a classical SVC will be performed instead.
 
     Notes
     -----
@@ -681,7 +681,7 @@ class QuanticMDM(QuanticClassifierBase):
         parametric circuit (ansatz).
     create_mixer : None | Callable[int, QuantumCircuit], default=None
         A delegate that takes into input an angle and returns a QuantumCircuit.
-        This circuit is the mixer operatior for the QAOA-CV algorithm.
+        This circuit is the mixer operator for the QAOA-CV algorithm.
         If None and quantum, the NaiveQAOAOptimizer will be used instead.
     n_reps : int, default=3
         The number of time the mixer and cost operator are repeated in the QAOA-CV
@@ -839,7 +839,7 @@ class QuanticNCH(QuanticClassifierBase):
         parametric circuit (ansatz).
     create_mixer : None | Callable[int, QuantumCircuit], default=None
         A delegate that takes into input an angle and returns a QuantumCircuit.
-        This circuit is the mixer operatior for the QAOA-CV algorithm.
+        This circuit is the mixer operator for the QAOA-CV algorithm.
         If None and quantum, the NaiveQAOAOptimizer will be used instead.
     n_reps : int, default=3
         The number of time the mixer and cost operator are repeated in the QAOA-CV

--- a/pyriemann_qiskit/datasets/utils.py
+++ b/pyriemann_qiskit/datasets/utils.py
@@ -238,7 +238,7 @@ class MockDataset:
         The code of the dataset, which is also the string representation
         of the dataset.
     data_ : dict
-        A dictionnary representing the dataset, e.g.:
+        A dictionary representing the dataset, e.g.:
         ``{subject1: (samples1, labels1), subject2: (samples2, labels2), ...}``
     subjects_ : list[int]
         The subjects of the dataset.

--- a/pyriemann_qiskit/ensemble.py
+++ b/pyriemann_qiskit/ensemble.py
@@ -113,7 +113,7 @@ class JudgeClassifier(BaseEstimator, ClassifierMixin):
         When classifiers clfs have the same prediction, the
         returned probability is the average of the probability of classifiers.
         When classifiers don't have the same predictions,
-        the returned probability is the the one of the judge classifier.
+        the returned probability is the one of the judge classifier.
 
         Parameters
         ----------

--- a/pyriemann_qiskit/utils/docplex.py
+++ b/pyriemann_qiskit/utils/docplex.py
@@ -66,7 +66,7 @@ def get_global_optimizer(default):
 
 
 def square_cont_mat_var(prob, channels, name="cont_spdmat"):
-    """ Docplex square continous matrix
+    """ Docplex square continuous matrix
 
     Creates a 2-dimensional dictionary of continuous decision variables,
     indexed by pairs of key objects.
@@ -82,7 +82,7 @@ def square_cont_mat_var(prob, channels, name="cont_spdmat"):
         The list of channels. A channel can be any Python object,
         such as channels'name or number but None.
     name : string
-        An custom name for the variable. The name is used internally by docplex
+        A custom name for the variable. The name is used internally by docplex
         and may appear if your print the model to a file for example.
 
     Returns
@@ -126,7 +126,7 @@ def square_int_mat_var(prob, channels, upper_bound=7, name="int_spdmat"):
     upper_bound : int (default: 7)
         The upper bound of the integer docplex variables.
     name : string
-        An custom name for the variable. The name is used internally by docplex
+        A custom name for the variable. The name is used internally by docplex
         and may appear if your print the model to a file for example.
 
     Returns
@@ -168,7 +168,7 @@ def square_bin_mat_var(prob, channels, name="bin_spdmat"):
         The list of channels. A channel can be any Python object,
         such as channels'name or number but None.
     name : string
-        An custom name for the variable. The name is used internally by docplex
+        A custom name for the variable. The name is used internally by docplex
         and may appear if your print the model to a file for example.
 
     Returns
@@ -245,7 +245,7 @@ class pyQiskitOptimizer:
             The list of channels. A channel can be any Python object,
             such as channels'name or number but None.
         name : string
-            An custom name for the variable. The name is used internally by docplex
+            A custom name for the variable. The name is used internally by docplex
             and may appear if your print the model to a file for example.
 
         Returns
@@ -369,7 +369,7 @@ class ClassicalOptimizer(pyQiskitOptimizer):
             The list of channels. A channel can be any Python object,
             such as channels'name or number but None.
         name : string
-            An custom name for the variable. The name is used internally by docplex
+            A custom name for the variable. The name is used internally by docplex
             and may appear if your print the model to a file for example.
 
         Returns
@@ -536,7 +536,7 @@ class NaiveQAOAOptimizer(pyQiskitOptimizer):
             The list of channels. A channel can be any Python object,
             such as channels'name or number but None.
         name : string
-            An custom name for the variable. The name is used internally by docplex
+            A custom name for the variable. The name is used internally by docplex
             and may appear if your print the model to a file for example.
 
         Returns
@@ -701,7 +701,7 @@ class QAOACVOptimizer(pyQiskitOptimizer):
             The list of channels. A channel can be any Python object,
             such as channels'name or number but None.
         name : string
-            An custom name for the variable. The name is used internally by docplex
+            A custom name for the variable. The name is used internally by docplex
             and may appear if your print the model to a file for example.
 
         Returns
@@ -759,7 +759,7 @@ class QAOACVOptimizer(pyQiskitOptimizer):
         # We want the object expression with continuous variable
         objective_expr = qp._objective
 
-        # Convert continous variable to binary ones
+        # Convert continuous variable to binary ones
         # Get scalers corresponding to the definition range of each variables
         qp, scalers = QAOACVOptimizer.prepare_model(qp)
 

--- a/pyriemann_qiskit/utils/firebase_connector.py
+++ b/pyriemann_qiskit/utils/firebase_connector.py
@@ -278,7 +278,7 @@ def generate_caches(datasets: list, pipelines: list, mock_data=None):
     Returns
     -------
     caches: Dict
-        A dictionnary containing all the generated caches, e.g.:
+        A dictionary containing all the generated caches, e.g.:
         ``caches[datasetA][pipeline1]``
         contains the cache for the ``datasetA`` and the ``pipeline1``.
 
@@ -309,7 +309,7 @@ def filter_subjects_by_incomplete_results(caches, datasets: list, pipelines: lis
     Parameters
     ----------
     caches: Dict
-        A dictionnary containing all the caches, e.g.:
+        A dictionary containing all the caches, e.g.:
         caches[datasetA][pipeline1]
         contains the cache for the datasetA and the pipeline1.
     datasets: List
@@ -320,7 +320,7 @@ def filter_subjects_by_incomplete_results(caches, datasets: list, pipelines: lis
     Returns
     -------
     results: Dict
-        A dictionnary of existing results, e.g.:
+        A dictionary of existing results, e.g.:
         results[datasetA][subjectA]
 
     Notes
@@ -367,7 +367,7 @@ def add_moabb_dataframe_results_to_caches(
     pipelines: List
         The sklearn Pipelines.
     caches: Dict
-        A dictionnary containing all the caches, e.g.:
+        A dictionary containing all the caches, e.g.:
         caches[datasetA][pipeline1]
         contains the cache for the datasetA and the pipeline1.
 
@@ -401,7 +401,7 @@ def convert_caches_to_dataframes(caches, datasets, pipelines):
     Parameters
     ----------
     caches: Dict
-        A dictionnary containing all the caches, e.g.:
+        A dictionary containing all the caches, e.g.:
         caches[datasetA][pipeline1]
         contains the cache for the datasetA and the pipeline1.
     datasets: List

--- a/pyriemann_qiskit/utils/hyper_params_factory.py
+++ b/pyriemann_qiskit/utils/hyper_params_factory.py
@@ -262,7 +262,7 @@ def get_spsa(max_trials=40, c=(None, None, None, None, 4.0)):
         Maximum number of iterations to perform.
     c : tuple[float | None] (default:(None, None, None, None, 4.0))
         The 5 control parameters for SPSA algorithms, namely:
-        the initial point, the intial perturbation, alpha, gamma
+        the initial point, the initial perturbation, alpha, gamma
         and the stability constant.
         See [3]_ for implementation details. This function set the
         default value of the control parameters for the `calibrate` method of

--- a/pyriemann_qiskit/utils/quantum_provider.py
+++ b/pyriemann_qiskit/utils/quantum_provider.py
@@ -148,7 +148,7 @@ def get_provider():
     -----
     .. versionadded:: 0.0.4
     .. versionchanged:: 0.1.0
-        IBMProvider is not a static API anymore but need to be instanciated.
+        IBMProvider is not a static API anymore but need to be instantiated.
     .. versionchanged:: 0.3.0
         Switch from IBMProvider to QiskitRuntimeService.
     """
@@ -191,7 +191,7 @@ def get_device(provider, min_qubits):
     provider: IBMProvider
         An instance of IBMProvider.
     min_qubits: int
-        The minimun of qubits.
+        The minimum of qubits.
 
     Returns
     -------

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -198,7 +198,7 @@ class TestQuanticVQC(BinaryFVT):
 
     def get_params(self):
         quantum_instance = QuanticVQC(verbose=False)
-        # To achieve testing in a reasonnable amount of time,
+        # To achieve testing in a reasonable amount of time,
         # you need to reduce the number of features and the number of samples
         return {
             "n_samples": 6,

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -9,7 +9,7 @@ class TestCommon:
         "dim_red", [NoDimRed(), NaiveDimRed(), NaiveDimRed(is_even=False)]
     )
     def test_fit(self, dim_red):
-        """Ensure all filtering can be instanciated,
+        """Ensure all filtering can be instantiated,
         and fitted.
         """
         X = np.array([[]])
@@ -32,8 +32,8 @@ class TestNaiveDimRed:
         "dim_red", [(NaiveDimRed(), True), (NaiveDimRed(is_even=False), False)]
     )
     def test_reduction(self, dim_red):
-        """Ensure the dimension of the feature is divied by two
-        and the the adequate indices are kept depending on wether the
+        """Ensure the dimension of the feature is divided by two
+        and the adequate indices are kept depending on whether the
         transform is Even or Odd.
         """
         X = np.array([[True, False], [True, False]])

--- a/tests/test_utils_hyper_params_factory.py
+++ b/tests/test_utils_hyper_params_factory.py
@@ -56,7 +56,7 @@ class TestGenZZFeatureMapParams:
         assert isinstance(feature_map.parameters, ParameterView)
 
     def test_entangl_invalid_value(self):
-        """Test gen_zz_feature_map with uncorrect value"""
+        """Test gen_zz_feature_map with incorrect value"""
         n_features = 2
         feature_map = gen_zz_feature_map(entanglement="invalid")(n_features)
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
**Fix typos**
- environements -> environments
- recommand -> recommend
- availabe -> available
- maxmium -> maximum
- Litterature -> Literature
- varitional -> variational
- writting -> writing
- runnin -> running
- bellow -> below
- synthethic -> synthetic
- caracterized -> characterized
- treatement -> treatment
- progamming -> programming
- differente -> different
- perfomed -> performed
- operatior -> operator
- dictionnary -> dictionary
- remove duplicate words for "the"
- continous -> continuous
- Fix grammer: An custom-> A custom
- intial -> initial
- instanciated -> instantiated
- minimun -> minimum
- reasonnable -> reasonable
- divied -> divided
- wether -> whether
- uncorrect -> incorrect